### PR TITLE
Change encoding of historical elements in MARC Schema

### DIFF
--- a/marc-schema/marc-schema-with-solr-and-extensions.json
+++ b/marc-schema/marc-schema-with-solr-and-extensions.json
@@ -24,18 +24,23 @@
           "solr": "leader05_recordStatus",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Increase in encoding level"
             },
             "c": {
+              "code": "c",
               "label": "Corrected or revised"
             },
             "d": {
+              "code": "d",
               "label": "Deleted"
             },
             "n": {
+              "code": "n",
               "label": "New"
             },
             "p": {
+              "code": "p",
               "label": "Increase in encoding level from prepublication"
             }
           }
@@ -49,57 +54,75 @@
           "solr": "leader06_typeOfRecord",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Language material"
             },
             "c": {
+              "code": "c",
               "label": "Notated music"
             },
             "d": {
+              "code": "d",
               "label": "Manuscript notated music"
             },
             "e": {
+              "code": "e",
               "label": "Cartographic material"
             },
             "f": {
+              "code": "f",
               "label": "Manuscript cartographic material"
             },
             "g": {
+              "code": "g",
               "label": "Projected medium"
             },
             "i": {
+              "code": "i",
               "label": "Nonmusical sound recording"
             },
             "j": {
+              "code": "j",
               "label": "Musical sound recording"
             },
             "k": {
+              "code": "k",
               "label": "Two-dimensional nonprojectable graphic"
             },
             "m": {
+              "code": "m",
               "label": "Computer file"
             },
             "o": {
+              "code": "o",
               "label": "Kit"
             },
             "p": {
+              "code": "p",
               "label": "Mixed materials"
             },
             "r": {
+              "code": "r",
               "label": "Three-dimensional artifact or naturally occurring object"
             },
             "t": {
+              "code": "t",
               "label": "Manuscript language material"
-            }
-          },
-          "historical-codes": {
+            },
             "b": {
-              "label": "Archival and manuscripts control [OBSOLETE, 1995]"
+              "code": "b",
+              "label": "Archival and manuscripts control [OBSOLETE, 1995]",
+              "deprecated": true
             },
             "h": {
-              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]"
+              "code": "h",
+              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]",
+              "deprecated": true
             },
             "n": {
-              "label": "Special instructional material"
+              "code": "n",
+              "label": "Special instructional material",
+              "deprecated": true
             }
           }
         },
@@ -112,30 +135,37 @@
           "solr": "leader07_bibliographicLevel",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Monographic component part"
             },
             "b": {
+              "code": "b",
               "label": "Serial component part"
             },
             "c": {
+              "code": "c",
               "label": "Collection"
             },
             "d": {
+              "code": "d",
               "label": "Subunit"
             },
             "i": {
+              "code": "i",
               "label": "Integrating resource"
             },
             "m": {
+              "code": "m",
               "label": "Monograph/Item"
             },
             "s": {
+              "code": "s",
               "label": "Serial"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]"
+              "code": "p",
+              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -148,9 +178,11 @@
           "solr": "leader08_typeOfControl",
           "codes": {
             " ": {
+              "code": " ",
               "label": "No specified type"
             },
             "a": {
+              "code": "a",
               "label": "Archival"
             }
           }
@@ -164,9 +196,11 @@
           "solr": "leader09_characterCodingScheme",
           "codes": {
             " ": {
+              "code": " ",
               "label": "MARC-8"
             },
             "a": {
+              "code": "a",
               "label": "UCS/Unicode"
             }
           }
@@ -180,6 +214,7 @@
           "solr": "leader10_indicatorCount",
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for indicators"
             }
           }
@@ -193,6 +228,7 @@
           "solr": "leader11_subfieldCodeCount",
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for a subfield code"
             }
           }
@@ -214,42 +250,54 @@
           "solr": "leader17_encodingLevel",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Full level"
             },
             "1": {
+              "code": "1",
               "label": "Full level, material not examined"
             },
             "2": {
+              "code": "2",
               "label": "Less-than-full level, material not examined"
             },
             "3": {
+              "code": "3",
               "label": "Abbreviated level"
             },
             "4": {
+              "code": "4",
               "label": "Core level"
             },
             "5": {
+              "code": "5",
               "label": "Partial (preliminary) level"
             },
             "7": {
+              "code": "7",
               "label": "Minimal level"
             },
             "8": {
+              "code": "8",
               "label": "Prepublication level"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
             },
             "z": {
+              "code": "z",
               "label": "Not applicable"
-            }
-          },
-          "historical-codes": {
+            },
             "0": {
-              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "0",
+              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             },
             "6": {
-              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "6",
+              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -262,30 +310,38 @@
           "solr": "leader18_descriptiveCatalogingForm",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Non-ISBD"
             },
             "a": {
+              "code": "a",
               "label": "AACR 2"
             },
             "c": {
+              "code": "c",
               "label": "ISBD punctuation omitted"
             },
             "i": {
+              "code": "i",
               "label": "ISBD punctuation included"
             },
             "n": {
+              "code": "n",
               "label": "Non-ISBD punctuation omitted"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Record is in partial ISBD form [OBSOLETE, 1987]"
+              "code": "p",
+              "label": "Record is in partial ISBD form [OBSOLETE, 1987]",
+              "deprecated": true
             },
             "r": {
-              "label": "Record is in provisional form [OBSOLETE, 1981]"
+              "code": "r",
+              "label": "Record is in provisional form [OBSOLETE, 1981]",
+              "deprecated": true
             }
           }
         },
@@ -298,24 +354,30 @@
           "solr": "leader19_multipartResourceRecordLevel",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Not specified or not applicable"
             },
             "a": {
+              "code": "a",
               "label": "Set"
             },
             "b": {
+              "code": "b",
               "label": "Part with independent title"
             },
             "c": {
+              "code": "c",
               "label": "Part with dependent title"
-            }
-          },
-          "historical-codes": {
+            },
             "r": {
-              "label": "Linked record requirement [OBSOLETE, 2007]"
+              "code": "r",
+              "label": "Linked record requirement [OBSOLETE, 2007]",
+              "deprecated": true
             },
             "2": {
-              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]"
+              "code": "2",
+              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -328,6 +390,7 @@
           "solr": "leader20_lengthOfTheLengthOfFieldPortion",
           "codes": {
             "4": {
+              "code": "4",
               "label": "Number of characters in the length-of-field portion of a Directory entry"
             }
           }
@@ -341,6 +404,7 @@
           "solr": "leader21_lengthOfTheStartingCharacterPositionPortion",
           "codes": {
             "5": {
+              "code": "5",
               "label": "Number of characters in the starting-character-position portion of a Directory entry"
             }
           }
@@ -354,6 +418,7 @@
           "solr": "leader22_lengthOfTheImplementationDefinedPortion",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Number of characters in the implementation-defined portion of a Directory entry"
             }
           }
@@ -367,6 +432,7 @@
           "solr": "leader23_undefined",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Undefined"
             }
           }
@@ -407,48 +473,63 @@
               "solr": "006all00_AdditionalMaterialCharacteristics_formOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Language material"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Notated music"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Manuscript notated music"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cartographic material"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Manuscript cartographic material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected medium"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nonmusical sound recording"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Musical sound recording"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Two-dimensional nonprojectable graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Computer file"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Mixed materials"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Three-dimensional artifact or naturally occurring object"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Serial/Integrating resource"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Manuscript language material"
                 }
               }
@@ -467,54 +548,71 @@
               "solr": "006book01_AdditionalMaterialCharacteristics_illustrations",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -528,33 +626,43 @@
               "solr": "006book05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -568,36 +676,47 @@
               "solr": "006book06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -612,90 +731,119 @@
               "solr": "006book07_AdditionalMaterialCharacteristics_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -709,39 +857,51 @@
               "solr": "006book11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -755,12 +915,15 @@
               "solr": "006book12_AdditionalMaterialCharacteristics_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -774,12 +937,15 @@
               "solr": "006book13_AdditionalMaterialCharacteristics_festschrift",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -793,12 +959,15 @@
               "solr": "006book14_AdditionalMaterialCharacteristics_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -812,42 +981,55 @@
               "solr": "006book16_AdditionalMaterialCharacteristics_literaryForm",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -861,21 +1043,27 @@
               "solr": "006book17_AdditionalMaterialCharacteristics_biography",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -893,33 +1081,43 @@
               "solr": "006computer05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -933,15 +1131,19 @@
               "solr": "006computer06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -955,45 +1157,59 @@
               "solr": "006computer09_AdditionalMaterialCharacteristics_typeOfComputerFile",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1007,39 +1223,51 @@
               "solr": "006computer11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1057,63 +1285,83 @@
               "solr": "006continuing01_AdditionalMaterialCharacteristics_frequency",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1127,18 +1375,23 @@
               "solr": "006continuing02_AdditionalMaterialCharacteristics_regularity",
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1152,27 +1405,35 @@
               "solr": "006continuing04_AdditionalMaterialCharacteristics_typeOfContinuingResource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1186,36 +1447,47 @@
               "solr": "006continuing05_AdditionalMaterialCharacteristics_formOfOriginalItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1229,36 +1501,47 @@
               "solr": "006continuing06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1272,87 +1555,115 @@
               "solr": "006continuing07_AdditionalMaterialCharacteristics_natureOfEntireWork",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1367,87 +1678,115 @@
               "solr": "006continuing08_AdditionalMaterialCharacteristics_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1461,39 +1800,51 @@
               "solr": "006continuing11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1507,12 +1858,15 @@
               "solr": "006continuing12_AdditionalMaterialCharacteristics_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1526,51 +1880,67 @@
               "solr": "006continuing16_AdditionalMaterialCharacteristics_originalAlphabetOrScriptOfTitle",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1584,15 +1954,19 @@
               "solr": "006continuing17_AdditionalMaterialCharacteristics_entryConvention",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1611,45 +1985,59 @@
               "solr": "006map01_AdditionalMaterialCharacteristics_relief",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1663,147 +2051,195 @@
               "solr": "006map05_AdditionalMaterialCharacteristics_projection",
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -1817,33 +2253,43 @@
               "solr": "006map08_AdditionalMaterialCharacteristics_typeOfCartographicMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1857,39 +2303,51 @@
               "solr": "006map11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1903,36 +2361,47 @@
               "solr": "006map12_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1946,12 +2415,15 @@
               "solr": "006map14_AdditionalMaterialCharacteristics_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1966,36 +2438,47 @@
               "solr": "006map16_AdditionalMaterialCharacteristics_specialFormatCharacteristics",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2013,36 +2496,47 @@
               "solr": "006mixed06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2060,222 +2554,295 @@
               "solr": "006music01_AdditionalMaterialCharacteristics_formOfComposition",
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -2289,54 +2856,71 @@
               "solr": "006music03_AdditionalMaterialCharacteristics_formatOfMusic",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2350,24 +2934,31 @@
               "solr": "006music04_AdditionalMaterialCharacteristics_musicParts",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2381,33 +2972,43 @@
               "solr": "006music05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2421,36 +3022,47 @@
               "solr": "006music06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2465,48 +3077,63 @@
               "solr": "006music07_AdditionalMaterialCharacteristics_accompanyingMatter",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Technical and/or historical information on instruments"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2521,69 +3148,91 @@
               "solr": "006music13_AdditionalMaterialCharacteristics_literaryTextForSoundRecordings",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2597,24 +3246,31 @@
               "solr": "006music16_AdditionalMaterialCharacteristics_transpositionAndArrangement",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2632,18 +3288,23 @@
               "solr": "006visual01_AdditionalMaterialCharacteristics_runningTime",
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -2657,33 +3318,43 @@
               "solr": "006visual05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2697,39 +3368,51 @@
               "solr": "006visual11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2743,36 +3426,47 @@
               "solr": "006visual12_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2786,66 +3480,87 @@
               "solr": "006visual16_AdditionalMaterialCharacteristics_typeOfVisualMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2859,24 +3574,31 @@
               "solr": "006visual17_AdditionalMaterialCharacteristics_technique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2901,48 +3623,63 @@
               "solr": "007common00_PhysicalDescription_categoryOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Map"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tactile material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected graphic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microform"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Nonprojected graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Notated music"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound recording"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Text"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Unspecified"
                 }
               }
@@ -2960,51 +3697,67 @@
               "solr": "007electro01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Tape cartridge"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Chip cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Computer optical disc cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer disc, type unspecified"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Computer disc cartridge, type unspecified"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tape cassette"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Tape reel"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magnetic disk"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Computer card"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Magneto-optical disc"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Optical disc"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Standalone device"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3018,36 +3771,45 @@
               "solr": "007electro03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Gray scale"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -3060,36 +3822,47 @@
               "solr": "007electro04_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 1/2 in."
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in."
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm."
                 },
                 "i": {
+                  "code": "i",
                   "label": "1 1/8 x 2 3/8 in."
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8 in."
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3103,15 +3876,19 @@
               "solr": "007electro05_PhysicalDescription_sound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3125,18 +3902,23 @@
               "solr": "007electro06_PhysicalDescription_imageBitDepth",
               "codes": {
                 "001-999": {
+                  "code": "001-999",
                   "label": "Exact bit depth"
                 },
                 "mmm": {
+                  "code": "mmm",
                   "label": "Multiple"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -3150,15 +3932,19 @@
               "solr": "007electro09_PhysicalDescription_fileFormats",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One file format"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple file formats"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3172,18 +3958,23 @@
               "solr": "007electro10_PhysicalDescription_qualityAssuranceTargets",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Absent"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Present"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3197,27 +3988,35 @@
               "solr": "007electro11_PhysicalDescription_antecedentOrSource",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "File reproduced from original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "File reproduced from microform"
                 },
                 "c": {
+                  "code": "c",
                   "label": "File reproduced from an electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "File reproduced from an intermediate (not microform)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3231,21 +4030,27 @@
               "solr": "007electro12_PhysicalDescription_levelOfCompression",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncompressed"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Lossless"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Lossy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3259,21 +4064,27 @@
               "solr": "007electro13_PhysicalDescription_reformattingQuality",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Access"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Preservation"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Replacement"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3291,30 +4102,37 @@
               "solr": "007globe01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Celestial globe"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Planetary or lunar globe"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Terrestrial globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Earth moon globe"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "d": {
-                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "d",
+                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -3327,18 +4145,21 @@
               "solr": "007globe03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3351,51 +4172,67 @@
               "solr": "007globe04_PhysicalDescription_physicalMedium",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3409,18 +4246,23 @@
               "solr": "007globe05_PhysicalDescription_typeOfReproduction",
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3438,9 +4280,11 @@
               "solr": "007kit01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3458,87 +4302,124 @@
               "solr": "007map01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Atlas"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Diagram"
                 },
                 "j": {
-                  "label": "Map"
+                  "code": "j",
+                  "label": "Orthophoto",
+                  "deprecated": true
                 },
                 "k": {
+                  "code": "k",
                   "label": "Profile"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Section"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "y": {
+                  "code": "y",
                   "label": "View"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Aerial chart"
+                  "code": "a",
+                  "label": "Aerial chart",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Aerial remote-sensing image"
+                  "code": "b",
+                  "label": "Aerial remote-sensing image",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Anamorphic map"
+                  "code": "c",
+                  "label": "Anamorphic map",
+                  "deprecated": true
                 },
                 "e": {
-                  "label": "Celestial chart"
+                  "code": "e",
+                  "label": "Celestial chart",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Chart"
+                  "code": "f",
+                  "label": "Chart",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Hydrographic chart"
+                  "code": "h",
+                  "label": "Hydrographic chart",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Imaginative map"
-                },
-                "j": {
-                  "label": "Orthophoto"
+                  "code": "i",
+                  "label": "Imaginative map",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Photo mosaic (controlled)"
+                  "code": "m",
+                  "label": "Photo mosaic (controlled)",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Photo mosaic (uncontrolled)"
+                  "code": "n",
+                  "label": "Photo mosaic (uncontrolled)",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Photomap"
+                  "code": "o",
+                  "label": "Photomap",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Plan"
+                  "code": "p",
+                  "label": "Plan",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Space remote-sensing image"
+                  "code": "t",
+                  "label": "Space remote-sensing image",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "Terrestrial remote-sensing image"
+                  "code": "v",
+                  "label": "Terrestrial remote-sensing image",
+                  "deprecated": true
                 },
                 "w": {
-                  "label": "Topographical drawing"
+                  "code": "w",
+                  "label": "Topographical drawing",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Topographical print"
+                  "code": "x",
+                  "label": "Topographical print",
+                  "deprecated": true
                 }
               }
             },
@@ -3551,18 +4432,21 @@
               "solr": "007map03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3575,72 +4459,95 @@
               "solr": "007map04_PhysicalDescription_physicalMedium",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Glass"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Flexible base photographic, positive"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Flexible base photographic, negative"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Non-flexible base photographic, positive"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Non-flexible base photographic, negative"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Not Applicable"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Other photographic medium"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3654,18 +4561,23 @@
               "solr": "007map05_PhysicalDescription_typeOfReproduction",
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3679,24 +4591,31 @@
               "solr": "007map06_PhysicalDescription_productionOrReproductionDetails",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Photocopy, blueline print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Photocopy"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Photographic pre-production"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Film"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3710,24 +4629,29 @@
               "solr": "007map07_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -3744,39 +4668,51 @@
               "solr": "007microform01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Aperture card"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfilm cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microfilm cassette"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Microfilm reel"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Microfiche"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Microfiche cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Microopaque"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microfilm slip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Microfilm roll"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3790,18 +4726,23 @@
               "solr": "007microform03_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3815,39 +4756,51 @@
               "solr": "007microform04_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "h": {
+                  "code": "h",
                   "label": "105 mm."
                 },
                 "l": {
+                  "code": "l",
                   "label": "3x5 in. or 8x13 cm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "4x6 in. or 11x15 cm."
                 },
                 "o": {
+                  "code": "o",
                   "label": "6x9 in. or 16x23 cm."
                 },
                 "p": {
+                  "code": "p",
                   "label": "3 1/4 x 7 3/8 in. or 9x19 cm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3861,27 +4814,35 @@
               "solr": "007microform05_PhysicalDescription_reductionRatioRange",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low reduction ratio"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Normal reduction"
                 },
                 "c": {
+                  "code": "c",
                   "label": "High reduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Very high reduction"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Ultra high reduction"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Reduction rate varies"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3903,21 +4864,27 @@
               "solr": "007microform09_PhysicalDescription_color",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3931,27 +4898,35 @@
               "solr": "007microform10_PhysicalDescription_emulsionOnFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Silver halide"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Diazo"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vesicular"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed emulsion"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3965,21 +4940,27 @@
               "solr": "007microform11_PhysicalDescription_generation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "First generation (master)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Printing master"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Service copy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed generation"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3993,45 +4974,57 @@
               "solr": "007microform12_PhysicalDescription_baseOfFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Not safety base [OBSOLETE, 1991]"
+                  "code": "b",
+                  "label": "Not safety base [OBSOLETE, 1991]",
+                  "deprecated": true
                 }
               }
             }
@@ -4048,24 +5041,31 @@
               "solr": "007motionPicture01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Film cartridge"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Film cassette"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Film roll"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Film reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4079,27 +5079,35 @@
               "solr": "007motionPicture03_PhysicalDescription_color",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4113,36 +5121,45 @@
               "solr": "007motionPicture04_PhysicalDescription_motionPicturePresentationFormat",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard sound aperture (reduced frame)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nonanamorphic (wide-screen)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "3D"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Anamorphic (wide-screen)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Other wide-screen format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Standard silent aperture (full frame)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1983]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1983]",
+                  "deprecated": true
                 }
               }
             },
@@ -4155,18 +5172,23 @@
               "solr": "007motionPicture05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4180,42 +5202,55 @@
               "solr": "007motionPicture06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Optical and magnetic sound track on motion picture film"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4229,33 +5264,43 @@
               "solr": "007motionPicture07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm."
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm."
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4269,27 +5314,35 @@
               "solr": "007motionPicture08_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4303,39 +5356,49 @@
               "solr": "007motionPicture09_PhysicalDescription_productionElements",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Workprint"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Trims"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Outtakes"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Rushes"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Mixing tracks"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Title bands/inter-title rolls"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Production rolls"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Other [OBSOLETE, 1988]"
+                  "code": "h",
+                  "label": "Other [OBSOLETE, 1988]",
+                  "deprecated": true
                 }
               }
             },
@@ -4348,21 +5411,27 @@
               "solr": "007motionPicture10_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4376,24 +5445,31 @@
               "solr": "007motionPicture11_PhysicalDescription_generation",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Duplicate"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Master"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Original"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reference print/viewing copy"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4407,39 +5483,51 @@
               "solr": "007motionPicture12_PhysicalDescription_baseOfFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4453,72 +5541,95 @@
               "solr": "007motionPicture13_PhysicalDescription_refinedCategoriesOfColor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 layer color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "2 color, single strip"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Undetermined 2 color"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Undetermined 3 color"
                 },
                 "e": {
+                  "code": "e",
                   "label": "3 strip color"
                 },
                 "f": {
+                  "code": "f",
                   "label": "2 strip color"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Red strip"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blue or green strip"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Cyan strip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magenta strip"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Yellow strip"
                 },
                 "l": {
+                  "code": "l",
                   "label": "S E N 2"
                 },
                 "m": {
+                  "code": "m",
                   "label": "S E N 3"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Sepia tone"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Other tone"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Tint"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Tinted and toned"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Stencil color"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Hand colored"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4532,27 +5643,35 @@
               "solr": "007motionPicture14_PhysicalDescription_kindOfColorStockOrPrint",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Imbibition dye transfer prints"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Three-layer stock"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Three layer stock, low fade"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Duplitized stock"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4566,39 +5685,51 @@
               "solr": "007motionPicture15_PhysicalDescription_deteriorationStage",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "None apparent"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nitrate: suspicious odor"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Nitrate: pungent odor"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Nitrate: brownish, discoloration, fading, dusty"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Nitrate: sticky"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Nitrate: frothy, bubbles, blisters"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Nitrate: congealed"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Nitrate: powder"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Non-nitrate: detectable deterioration"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Non-nitrate: advanced deterioration"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Non-nitrate: disaster"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4612,18 +5743,23 @@
               "solr": "007motionPicture16_PhysicalDescription_completeness",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Complete"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Incomplete"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4649,66 +5785,87 @@
               "solr": "007nonprojected01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Activity card"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drawing"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Painting"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Photomechanical print"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Photonegative"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Photoprint"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Print"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Poster"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Postcard"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Icon"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Radiograph"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Study print"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Photograph, type unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4722,27 +5879,35 @@
               "solr": "007nonprojected03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4756,72 +5921,95 @@
               "solr": "007nonprojected04_PhysicalDescription_primarySupportMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4835,75 +6023,99 @@
               "solr": "007nonprojected05_PhysicalDescription_secondarySupportMaterial",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4921,9 +6133,11 @@
               "solr": "007music01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4941,39 +6155,50 @@
               "solr": "007projected01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Filmstrip cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Filmslip"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip, type unspecified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Filmstrip roll"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -4986,30 +6211,39 @@
               "solr": "007projected03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5023,39 +6257,50 @@
               "solr": "007projected04_PhysicalDescription_baseOfEmulsion",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Safety film"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Film base, other than safety film"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -5068,18 +6313,23 @@
               "solr": "007projected05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5093,48 +6343,57 @@
               "solr": "007projected06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1981]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1981]"
                 }
               }
             },
@@ -5147,66 +6406,78 @@
               "solr": "007projected07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm. film width"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm. film width"
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm. film width"
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm. film width"
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm. film width"
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm. film width"
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm. film width"
                 },
                 "j": {
+                  "code": "j",
                   "label": "2x2 in. or 5x5 cm. slide"
                 },
                 "k": {
+                  "code": "k",
                   "label": "2 1/4 x 2 1/4 in. or 6x6 cm. slide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "4x5 in. or 10x13 cm. transparency"
                 },
                 "t": {
+                  "code": "t",
                   "label": "5x7 in. or 13x18 cm. transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8x10 in. or 21x26 cm. transparency"
                 },
                 "w": {
+                  "code": "w",
                   "label": "9x9 in. or 23x23 cm. transparency"
                 },
                 "x": {
+                  "code": "x",
                   "label": "10x10 in. or 26x26 cm. transparency"
                 },
                 "y": {
-                  "label": "7x7 in. or 18x18 cm. transparency"
+                  "code": "y",
+                  "label": "Unknown [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "u": {
-                  "label": "Unknown"
+                  "code": "u",
+                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "u": {
-                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]"
-                },
-                "y": {
-                  "label": "Unknown [OBSOLETE, 1980]"
                 }
               }
             },
@@ -5219,36 +6490,47 @@
               "solr": "007projected08_PhysicalDescription_secondarySupportMaterial",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Metal and glass"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Synthetic and glass"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5266,15 +6548,17 @@
               "solr": "007remoteSensing01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "No type specified [OBSOLETE, 1998]"
+                  "code": " ",
+                  "label": "No type specified [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             },
@@ -5287,24 +6571,31 @@
               "solr": "007remoteSensing03_PhysicalDescription_altitudeOfSensor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Surface"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Airborne"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Spaceborne"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5318,21 +6609,27 @@
               "solr": "007remoteSensing04_PhysicalDescription_attitudeOfSensor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low oblique"
                 },
                 "b": {
+                  "code": "b",
                   "label": "High oblique"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vertical"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5346,42 +6643,55 @@
               "solr": "007remoteSensing05_PhysicalDescription_cloudCover",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "0-9%"
                 },
                 "1": {
+                  "code": "1",
                   "label": "10-19%"
                 },
                 "2": {
+                  "code": "2",
                   "label": "20-29%"
                 },
                 "3": {
+                  "code": "3",
                   "label": "30-39%"
                 },
                 "4": {
+                  "code": "4",
                   "label": "40-49%"
                 },
                 "5": {
+                  "code": "5",
                   "label": "50-59%"
                 },
                 "6": {
+                  "code": "6",
                   "label": "60-69%"
                 },
                 "7": {
+                  "code": "7",
                   "label": "70-79%"
                 },
                 "8": {
+                  "code": "8",
                   "label": "80-89%"
                 },
                 "9": {
+                  "code": "9",
                   "label": "90-100%"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5395,42 +6705,55 @@
               "solr": "007remoteSensing06_PhysicalDescription_platformConstructionType",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Balloon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Aircraft--low altitude"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Aircraft--medium altitude"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Aircraft--high altitude"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manned spacecraft"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Unmanned spacecraft"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Land-based remote-sensing device"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Water surface-based remote-sensing device"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Submersible remote-sensing device"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5444,27 +6767,35 @@
               "solr": "007remoteSensing07_PhysicalDescription_platformUseCategory",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Meteorological"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Surface observing"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Space observing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed uses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5478,18 +6809,23 @@
               "solr": "007remoteSensing08_PhysicalDescription_sensorType",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Active"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Passive"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5503,129 +6839,171 @@
               "solr": "007remoteSensing09_PhysicalDescription_dataType",
               "codes": {
                 "aa": {
+                  "code": "aa",
                   "label": "Visible light"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Near infrared"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Middle infrared"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Far infrared"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Thermal infrared"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Shortwave infrared (SWIR)"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Reflective infrared"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Combinations"
                 },
                 "dz": {
+                  "code": "dz",
                   "label": "Other infrared data"
                 },
                 "ga": {
+                  "code": "ga",
                   "label": "Sidelooking airborne radar (SLAR)"
                 },
                 "gb": {
+                  "code": "gb",
                   "label": "Synthetic aperture radar (SAR)-Single frequency"
                 },
                 "gc": {
+                  "code": "gc",
                   "label": "SAR-multi-frequency (multichannel)"
                 },
                 "gd": {
+                  "code": "gd",
                   "label": "SAR-like polarization"
                 },
                 "ge": {
+                  "code": "ge",
                   "label": "SAR-cross polarization"
                 },
                 "gf": {
+                  "code": "gf",
                   "label": "Infometric SAR"
                 },
                 "gg": {
+                  "code": "gg",
                   "label": "polarmetric SAR"
                 },
                 "gu": {
+                  "code": "gu",
                   "label": "Passive microwave mapping"
                 },
                 "gz": {
+                  "code": "gz",
                   "label": "Other microwave data"
                 },
                 "ja": {
+                  "code": "ja",
                   "label": "Far ultraviolet"
                 },
                 "jb": {
+                  "code": "jb",
                   "label": "Middle ultraviolet"
                 },
                 "jc": {
+                  "code": "jc",
                   "label": "Near ultraviolet"
                 },
                 "jv": {
+                  "code": "jv",
                   "label": "Ultraviolet combinations"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Other ultraviolet data"
                 },
                 "ma": {
+                  "code": "ma",
                   "label": "Multi-spectral, multidata"
                 },
                 "mb": {
+                  "code": "mb",
                   "label": "Multi-temporal"
                 },
                 "mm": {
+                  "code": "mm",
                   "label": "Combination of various data types"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "pa": {
+                  "code": "pa",
                   "label": "Sonar--water depth"
                 },
                 "pb": {
+                  "code": "pb",
                   "label": "Sonar--bottom topography images, sidescan"
                 },
                 "pc": {
+                  "code": "pc",
                   "label": "Sonar--bottom topography, near-surface"
                 },
                 "pd": {
+                  "code": "pd",
                   "label": "Sonar--bottom topography, near-bottom"
                 },
                 "pe": {
+                  "code": "pe",
                   "label": "Seismic surveys"
                 },
                 "pz": {
+                  "code": "pz",
                   "label": "Other acoustical data"
                 },
                 "ra": {
+                  "code": "ra",
                   "label": "Gravity anomalies (general)"
                 },
                 "rb": {
+                  "code": "rb",
                   "label": "Free-air"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Bouger"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Isostatic"
                 },
                 "sa": {
+                  "code": "sa",
                   "label": "Magnetic field"
                 },
                 "ta": {
+                  "code": "ta",
                   "label": "radiometric surveys"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -5643,54 +7021,67 @@
               "solr": "007soundRecording01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Belt"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cylinder"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Sound cartridge"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Sound-track film"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Roll"
                 },
                 "r": {
-                  "label": "Remote"
+                  "code": "r",
+                  "label": "Roll [OBSOLETE]",
+                  "deprecated": true
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound cassette"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Sound-tape reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wire recording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "c": {
-                  "label": "Cylinder [OBSOLETE]"
+                  "code": "c",
+                  "label": "Cylinder [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Sound-track film [OBSOLETE]"
-                },
-                "r": {
-                  "label": "Roll [OBSOLETE]"
+                  "code": "f",
+                  "label": "Sound-track film [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5703,57 +7094,75 @@
               "solr": "007soundRecording03_PhysicalDescription_speed",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "16 rpm (discs)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "33 1/3 rpm (discs)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "45 rpm (discs)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "78 rpm (discs)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "8 rpm (discs)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "1.4 m. per second (discs)"
                 },
                 "h": {
+                  "code": "h",
                   "label": "120 rpm (cylinders)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "160 rpm (cylinders)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "15/16 ips (tapes)"
                 },
                 "l": {
+                  "code": "l",
                   "label": "1 7/8 ips (tapes)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "3 3/4 ips (tapes)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "7 1/2 ips (tapes)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "15 ips (tapes)"
                 },
                 "r": {
+                  "code": "r",
                   "label": "30 ips (tape)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5767,42 +7176,58 @@
               "solr": "007soundRecording04_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Acoustic [OBSOLETE]"
+                  "code": "a",
+                  "label": "Acoustic [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Monaural (digital) [OBSOLETE]"
+                  "code": "f",
+                  "label": "Monaural (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Quadraphonic (digital) [OBSOLETE]"
+                  "code": "g",
+                  "label": "Quadraphonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Stereophonic (digital) [OBSOLETE]"
+                  "code": "j",
+                  "label": "Stereophonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Other (digital) [OBSOLETE]"
+                  "code": "k",
+                  "label": "Other (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other (electric) [OBSOLETE]"
+                  "code": "o",
+                  "label": "Other (electric) [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5815,21 +7240,27 @@
               "solr": "007soundRecording05_PhysicalDescription_grooveWidthOrGroovePitch",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Microgroove/fine"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Coarse/standard"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5843,45 +7274,59 @@
               "solr": "007soundRecording06_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 in. diameter"
                 },
                 "b": {
+                  "code": "b",
                   "label": "5 in. diameter"
                 },
                 "c": {
+                  "code": "c",
                   "label": "7 in. diameter"
                 },
                 "d": {
+                  "code": "d",
                   "label": "10 in. diameter"
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in. diameter"
                 },
                 "f": {
+                  "code": "f",
                   "label": "16 in. diameter"
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm. diameter"
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 x 3 7/8 in."
                 },
                 "s": {
+                  "code": "s",
                   "label": "2 3/4 x 4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5895,39 +7340,51 @@
               "solr": "007soundRecording07_PhysicalDescription_tapeWidth",
               "codes": {
                 "l": {
+                  "code": "l",
                   "label": "1/8 in."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "1/4 in. [OBSOLETE]"
+                  "code": "a",
+                  "label": "1/4 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "1/2 in. [OBSOLETE]"
+                  "code": "b",
+                  "label": "1/2 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "1 in. [OBSOLETE]"
+                  "code": "c",
+                  "label": "1 in. [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5940,33 +7397,43 @@
               "solr": "007soundRecording08_PhysicalDescription_tapeConfiguration",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full (1) track"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Half (2) track"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Quarter (4) track"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Eight track"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Twelve track"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Sixteen track"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5980,39 +7447,51 @@
               "solr": "007soundRecording09_PhysicalDescription_kindOfDiscCylinderOrTape",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Master tape"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Tape duplication master"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Disc master (negative)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instantaneous (recorded on the spot)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mass-produced"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Mother (positive)"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stamper (negative)"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Test pressing"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6026,48 +7505,63 @@
               "solr": "007soundRecording10_PhysicalDescription_kindOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Lacquer coating"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Cellulose nitrate"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Acetate tape with ferrous oxide"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Glass with lacquer"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Aluminum with lacquer"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Metal"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Plastic with metal"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plastic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Paper with lacquer or ferrous oxide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shellac"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wax"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6081,18 +7575,23 @@
               "solr": "007soundRecording11_PhysicalDescription_kindOfCutting",
               "codes": {
                 "h": {
+                  "code": "h",
                   "label": "Hill-and-dale cutting"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lateral or combined cutting"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6106,39 +7605,51 @@
               "solr": "007soundRecording12_PhysicalDescription_specialPlaybackCharacteristics",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "NAB standard"
                 },
                 "b": {
+                  "code": "b",
                   "label": "CCIR standard"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Dolby-B encoded"
                 },
                 "d": {
+                  "code": "d",
                   "label": "dbx encoded"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Digital recording"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Dolby-A encoded"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Dolby-C encoded"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CX encoded"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6152,24 +7663,31 @@
               "solr": "007soundRecording13_PhysicalDescription_captureAndStorageTechnique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Acoustical capture, analog direct storage"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Electrical capture, analog direct storage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Electrical capture, digital storage"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Electrical capture, analog electrical storage"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown capture and storage"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6187,24 +7705,31 @@
               "solr": "007tactile01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Moon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Combination"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Tactile, with no writing system"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6219,36 +7744,47 @@
               "solr": "007tactile03_PhysicalDescription_classOfBrailleWriting",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified class of braille writing"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Literary braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Format code braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Mathematics and scientific braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer braille"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Music braille"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple braille types"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6262,24 +7798,31 @@
               "solr": "007tactile05_PhysicalDescription_levelOfContraction",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncontracted"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Contracted"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6294,54 +7837,71 @@
               "solr": "007tactile06_PhysicalDescription_brailleMusicFormat",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified braille music format"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Bar over bar"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bar by bar"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Line over line"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Paragraph"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Single line"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Section by section"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Line by line"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Open score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Spanner short form scoring"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short form scoring"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Outline"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vertical score"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6355,21 +7915,27 @@
               "solr": "007tactile09_PhysicalDescription_specialPhysicalCharacteristics",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Print/braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Jumbo or enlarged braille"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6387,24 +7953,31 @@
               "solr": "007text01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Regular print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Large print"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Loose-leaf"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6422,15 +7995,19 @@
               "solr": "007unspecified01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Multiple physical forms"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6448,33 +8025,42 @@
               "solr": "007video01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Videocartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Videodisc"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Videocassette"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Videoreel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6487,27 +8073,35 @@
               "solr": "007video03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6521,72 +8115,94 @@
               "solr": "007video04_PhysicalDescription_videorecordingFormat",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Beta (1/2 in., videocassette)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "VHS (1/2 in., videocassette)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "U-matic (3/4 in., videocasstte)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "EIAJ (1/2 in., reel)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Type C (1 in., reel)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Quadruplex (1 in. or 2 in., reel)"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Laserdisc"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CED (Capacitance Electronic Disc) videodisc"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Betacam (1/2 in., videocassette)"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Betacam SP (1/2 in., videocassette)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Super-VHS (1/2 in., videocassette)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "M-II (1/2 in., videocassette)"
                 },
                 "o": {
+                  "code": "o",
                   "label": "D-2 (3/4 in., videocassette)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "8 mm."
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hi-8 mm."
                 },
                 "s": {
+                  "code": "s",
                   "label": "Blu-ray disc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "DVD"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6599,18 +8215,23 @@
               "solr": "007video05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6624,48 +8245,57 @@
               "solr": "007video06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1980]"
                 }
               }
             },
@@ -6678,36 +8308,45 @@
               "solr": "007video07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "q": {
+                  "code": "q",
                   "label": "2 in."
                 },
                 "r": {
+                  "code": "r",
                   "label": "3/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "1/4 in. [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "1/4 in. [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6720,27 +8359,35 @@
               "solr": "007video08_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6773,48 +8420,63 @@
               "solr": "008all06_GeneralInformation_typeOfDateOrPublicationStatus",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "No dates given; B.C. date involved"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Continuing resource currently published"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Continuing resource ceased publication"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Detailed date"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Inclusive dates of collection"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Range of years of bulk of collection"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple dates"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Dates unknown"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Date of distribution/release/issue and production/recording session when different"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Questionable date"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reprint/reissue date and original date"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Single known date/probable date"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Publication date and copyright date"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Continuing resource status unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6860,30 +8522,37 @@
               "solr": "008all38_GeneralInformation_modifiedRecord",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not modified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dashed-on information omitted"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Completely romanized/printed cards romanized"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Completely romanized/printed cards in script"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shortened"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Missing characters"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -6896,39 +8565,54 @@
               "solr": "008all39_GeneralInformation_catalogingSource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "National bibliographic agency"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cooperative cataloging program"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Other"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]"
+                  "code": "a",
+                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]"
+                  "code": "b",
+                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "l",
+                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "o",
+                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]"
+                  "code": "n",
+                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -6946,54 +8630,71 @@
               "solr": "008book18_GeneralInformation_illustrations",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7007,42 +8708,54 @@
               "solr": "008book22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -7055,51 +8768,68 @@
               "solr": "008book23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -7113,105 +8843,140 @@
               "solr": "008book24_GeneralInformation_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Handbooks [OBSOLETE]"
+                  "code": "h",
+                  "label": "Handbooks [OBSOLETE]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Technical reports [OBSOLETE, 1997]"
+                  "code": "x",
+                  "label": "Technical reports [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7224,45 +8989,57 @@
               "solr": "008book28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -7275,12 +9052,15 @@
               "solr": "008book29_GeneralInformation_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7294,12 +9074,15 @@
               "solr": "008book30_GeneralInformation_festschrift",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7313,12 +9096,15 @@
               "solr": "008book31_GeneralInformation_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7332,51 +9118,66 @@
               "solr": "008book33_GeneralInformation_literaryForm",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Non-fiction [OBSOLETE, 1997]"
+                  "code": " ",
+                  "label": "Non-fiction [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Comic strips [OBSOLETE, 2008]"
+                  "code": "c",
+                  "label": "Comic strips [OBSOLETE, 2008]",
+                  "deprecated": true
                 }
               }
             },
@@ -7389,21 +9190,27 @@
               "solr": "008book34_GeneralInformation_biography",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7421,33 +9228,43 @@
               "solr": "008computer22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7461,15 +9278,19 @@
               "solr": "008computer23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7483,45 +9304,59 @@
               "solr": "008computer26_GeneralInformation_typeOfComputerFile",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7535,39 +9370,51 @@
               "solr": "008computer28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7585,63 +9432,83 @@
               "solr": "008continuing18_GeneralInformation_frequency",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7655,18 +9522,23 @@
               "solr": "008continuing19_GeneralInformation_regularity",
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7680,45 +9552,59 @@
               "solr": "008continuing21_GeneralInformation_typeOfContinuingResource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Magazine"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blog"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Journal"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Repository"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Newsletter"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Directory"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7732,36 +9618,47 @@
               "solr": "008continuing22_GeneralInformation_formOfOriginalItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7775,51 +9672,68 @@
               "solr": "008continuing23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -7832,96 +9746,126 @@
               "solr": "008continuing24_GeneralInformation_natureOfEntireWork",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7935,96 +9879,126 @@
               "solr": "008continuing25_GeneralInformation_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -8037,45 +10011,57 @@
               "solr": "008continuing28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -8088,12 +10074,15 @@
               "solr": "008continuing29_GeneralInformation_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8107,51 +10096,67 @@
               "solr": "008continuing33_GeneralInformation_originalAlphabetOrScriptOfTitle",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8165,15 +10170,19 @@
               "solr": "008continuing34_GeneralInformation_entryConvention",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8192,51 +10201,65 @@
               "solr": "008map18_GeneralInformation_relief",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Color [OBSOLETE, 1980]"
+                  "code": "h",
+                  "label": "Color [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             },
@@ -8249,147 +10272,195 @@
               "solr": "008map22_GeneralInformation_projection",
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8403,33 +10474,43 @@
               "solr": "008map25_GeneralInformation_typeOfCartographicMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8443,39 +10524,51 @@
               "solr": "008map28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8489,36 +10582,47 @@
               "solr": "008map29_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8532,12 +10636,15 @@
               "solr": "008map31_GeneralInformation_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8552,66 +10659,93 @@
               "solr": "008map33_GeneralInformation_specialFormatCharacteristics",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Photocopy, blue line print [OBSOLETE, 1982]"
+                  "code": "a",
+                  "label": "Photocopy, blue line print [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Photocopy [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Negative photocopy [OBSOLETE, 1982]"
+                  "code": "c",
+                  "label": "Negative photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "d": {
-                  "label": "Film negative [OBSOLETE, 1982]"
+                  "code": "d",
+                  "label": "Film negative [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Facsimile [OBSOLETE, 1982]"
+                  "code": "f",
+                  "label": "Facsimile [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Relief model [OBSOLETE, 1982]"
+                  "code": "g",
+                  "label": "Relief model [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Rare [OBSOLETE, 1982]"
+                  "code": "h",
+                  "label": "Rare [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Braille [OBSOLETE, 1998]"
+                  "code": "m",
+                  "label": "Braille [OBSOLETE, 1998]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Large print [OBSOLETE, 1998]"
+                  "code": "q",
+                  "label": "Large print [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             }
@@ -8628,60 +10762,83 @@
               "solr": "008mixed23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Handwritten transcript [OBSOLETE, 1987]"
+                  "code": "j",
+                  "label": "Handwritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Photocopy [OBSOLETE, 1987]"
+                  "code": "p",
+                  "label": "Photocopy [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Typewritten transcript [OBSOLETE, 1987]"
+                  "code": "t",
+                  "label": "Typewritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             }
@@ -8698,222 +10855,295 @@
               "solr": "008music18_GeneralInformation_formOfComposition",
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8927,54 +11157,71 @@
               "solr": "008music20_GeneralInformation_formatOfMusic",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8988,30 +11235,37 @@
               "solr": "008music21_GeneralInformation_musicParts",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Parts exist"
+                  "code": "a",
+                  "label": "Parts exist",
+                  "deprecated": true
                 }
               }
             },
@@ -9024,42 +11278,54 @@
               "solr": "008music22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -9072,54 +11338,73 @@
               "solr": "008music23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]"
+                  "code": "x",
+                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -9133,63 +11418,80 @@
               "solr": "008music24_GeneralInformation_accompanyingMatter",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
-                  "label": "Technical and/or historical information on instruments"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Historical information other than music [OBSOLETE, 1980]"
+                  "code": "j",
+                  "label": "Historical information other than music [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]"
+                  "code": "l",
+                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -9203,69 +11505,91 @@
               "solr": "008music30_GeneralInformation_literaryTextForSoundRecordings",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9279,24 +11603,31 @@
               "solr": "008music33_GeneralInformation_transpositionAndArrangement",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9314,18 +11645,23 @@
               "solr": "008visual18_GeneralInformation_runningTime",
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -9339,66 +11675,86 @@
               "solr": "008visual22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
-                  "label": "Specialized"
+                  "code": "f",
+                  "label": "General [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "General"
+                  "code": "g",
+                  "label": "Specialized [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "f": {
-                  "label": "General [OBSOLETE]"
-                },
-                "g": {
-                  "label": "Specialized [OBSOLETE]"
                 },
                 "h": {
-                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]"
+                  "code": "k",
+                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]"
+                  "code": "m",
+                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]"
+                  "code": "p",
+                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]"
+                  "code": "q",
+                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "s": {
-                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]"
+                  "code": "s",
+                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Gifted [OBSOLETE] [CAN/MARC only]"
+                  "code": "t",
+                  "label": "Gifted [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -9411,45 +11767,57 @@
               "solr": "008visual28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -9462,36 +11830,47 @@
               "solr": "008visual29_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9505,72 +11884,93 @@
               "solr": "008visual33_GeneralInformation_typeOfVisualMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "e": {
-                  "label": "Electronic videorecording [OBSOLETE, 1975]"
+                  "code": "e",
+                  "label": "Electronic videorecording [OBSOLETE, 1975]",
+                  "deprecated": true
                 }
               }
             },
@@ -9583,30 +11983,37 @@
               "solr": "008visual34_GeneralInformation_technique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             }
@@ -9895,9 +12302,11 @@
         "label": "National bibliographic agency",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library and Archives Canada"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -9958,9 +12367,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Copyright or legal deposit number"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -10152,6 +12563,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0208_Isbn_fieldLink"
+        },
+        "b": {
+          "label": "Binding information (BK, MP, MU) [OBSOLETE]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -10179,11 +12594,6 @@
             "solr": "020x23_Isbn_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Binding information (BK, MP, MU) [OBSOLETE]"
-        }
       }
     },
     "022": {
@@ -10197,12 +12607,15 @@
         "label": "Level of international interest",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "0": {
+            "code": "0",
             "label": "Continuing resource of international interest"
           },
           "1": {
+            "code": "1",
             "label": "Continuing resource not of international interest"
           }
         }
@@ -10260,6 +12673,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0228_Issn_fieldLink"
+        },
+        "b": {
+          "label": "Form of issue [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
+        },
+        "c": {
+          "label": "Price [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -10280,14 +12701,6 @@
             "solr": "022x23_Issn_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Form of issue [OBSOLETE] [CAN/MARC only]"
-        },
-        "c": {
-          "label": "Price [OBSOLETE] [CAN/MARC only]"
-        }
       }
     },
     "024": {
@@ -10301,24 +12714,31 @@
         "label": "Type of standard number or code",
         "codes": {
           "0": {
+            "code": "0",
             "label": "International Standard Recording Code"
           },
           "1": {
+            "code": "1",
             "label": "Universal Product Code"
           },
           "2": {
+            "code": "2",
             "label": "International Standard Music Number"
           },
           "3": {
+            "code": "3",
             "label": "International Article Number"
           },
           "4": {
+            "code": "4",
             "label": "Serial Item and Contribution Identifier"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Unspecified type of standard number or code"
           }
         }
@@ -10327,12 +12747,15 @@
         "label": "Difference indicator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No difference"
           },
           "1": {
+            "code": "1",
             "label": "Difference"
           }
         }
@@ -10379,6 +12802,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0248_OtherStandardIdentifier_fieldLink"
+        },
+        "b": {
+          "label": "Additional codes following the standard number [OBSOLETE]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -10405,11 +12832,6 @@
             "repeatable": false,
             "solr": "024x23_OtherStandardIdentifier_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Additional codes following the standard number [OBSOLETE]"
         }
       }
     },
@@ -10601,24 +13023,31 @@
         "label": "Type of number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Issue number"
           },
           "1": {
+            "code": "1",
             "label": "Matrix number"
           },
           "2": {
+            "code": "2",
             "label": "Plate number"
           },
           "3": {
+            "code": "3",
             "label": "Other music publisher number"
           },
           "4": {
+            "code": "4",
             "label": "Video recording publisher number"
           },
           "5": {
+            "code": "5",
             "label": "Other publisher number"
           },
           "6": {
+            "code": "6",
             "label": "Distributor number"
           }
         }
@@ -10627,15 +13056,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "Note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -10699,9 +13132,11 @@
         "label": "The type of system control number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Primary control number"
           },
           "1": {
+            "code": "1",
             "label": "Secondary control number"
           }
         }
@@ -10978,15 +13413,19 @@
         "label": "Type of date in subfield $a",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No date information"
           },
           "0": {
+            "code": "0",
             "label": "Single date"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates"
           }
         }
@@ -10995,15 +13434,19 @@
         "label": "Type of event",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Capture"
           },
           "1": {
+            "code": "1",
             "label": "Broadcast"
           },
           "2": {
+            "code": "2",
             "label": "Finding"
           }
         }
@@ -11094,18 +13537,21 @@
         "label": "Type of scale",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Scale indeterminable/No scale recorded"
           },
           "1": {
+            "code": "1",
             "label": "Single scale"
           },
           "3": {
+            "code": "3",
             "label": "Range of scales"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -11113,12 +13559,15 @@
         "label": "Type of ring",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Outer ring"
           },
           "1": {
+            "code": "1",
             "label": "Exclusion ring"
           }
         }
@@ -11410,12 +13859,15 @@
         "label": "Source of acquisition sequence",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -11553,9 +14005,11 @@
         "label": "National Bibliography Issue Number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "British National Bibliography or British Catalogue of Music – Interim issue"
           },
           "1": {
+            "code": "1",
             "label": "British Catalogue of Music – Annual cumulation"
           }
         }
@@ -11666,12 +14120,15 @@
         "label": "Translation indication",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item not a translation/does not include a translation"
           },
           "1": {
+            "code": "1",
             "label": "Item is or includes a translation"
           }
         }
@@ -11680,9 +14137,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -11809,6 +14268,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0418_Language_fieldLink"
+        },
+        "c": {
+          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -11828,11 +14291,6 @@
             "repeatable": false,
             "solr": "041x23_Language_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]"
         }
       }
     },
@@ -12030,15 +14488,19 @@
         "label": "Type of time period in subfield $b or $c",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Subfield $b or $c not present"
           },
           "0": {
+            "code": "0",
             "label": "Single date/time"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates/times"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates/times"
           }
         }
@@ -12103,15 +14565,19 @@
         "label": "Type of entity",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Work"
           },
           "2": {
+            "code": "2",
             "label": "Expression"
           },
           "3": {
+            "code": "3",
             "label": "Manifestation"
           }
         }
@@ -12243,9 +14709,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC musical composition code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -12300,9 +14768,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -12400,12 +14870,15 @@
         "label": "Existence in LC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in LC"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in LC"
           }
         }
@@ -12414,27 +14887,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by LC"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided"
           },
-          "0": {
-            "label": "No series involved"
+          " ": {
+            "code": " ",
+            "label": "No information provided",
+            "deprecated": true
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           }
         }
       },
@@ -12475,6 +14954,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0508_ClassificationLcc_fieldLink"
+        },
+        "d": {
+          "label": "Supplementary class number (MU) [OBSOLETE, 1981]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -12494,11 +14977,6 @@
             "repeatable": false,
             "solr": "050x23_ClassificationLcc_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Supplementary class number (MU) [OBSOLETE, 1981]"
         }
       }
     },
@@ -12564,18 +15042,21 @@
         "label": "Code source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library of Congress Classification"
           },
           "1": {
+            "code": "1",
             "label": "U.S. Dept. of Defense Classification"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]"
+            "code": "0",
+            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]",
+            "deprecated": true
           }
         }
       },
@@ -12623,6 +15104,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0528_GeographicClassification_fieldLink"
+        },
+        "c": {
+          "label": "Subject (MP) [OBSOLETE]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -12643,11 +15128,6 @@
             "solr": "052x23_GeographicClassification_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Subject (MP) [OBSOLETE]"
-        }
       }
     },
     "055": {
@@ -12661,12 +15141,15 @@
         "label": "Existence in LAC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Information not provided"
           },
           "0": {
+            "code": "0",
             "label": "Work held by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Work not held by LAC"
           }
         }
@@ -12675,33 +15158,43 @@
         "label": "Type, completeness, source of class/call number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "LC-based call number assigned by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Complete LC class number assigned by LAC"
           },
           "2": {
+            "code": "2",
             "label": "Incomplete LC class number assigned by LAC"
           },
           "3": {
+            "code": "3",
             "label": "LC-based call number assigned by the contributing library"
           },
           "4": {
+            "code": "4",
             "label": "Complete LC class number assigned by the contributing library"
           },
           "5": {
+            "code": "5",
             "label": "Incomplete LC class number assigned by the contributing library"
           },
           "6": {
+            "code": "6",
             "label": "Other call number assigned by LAC"
           },
           "7": {
+            "code": "7",
             "label": "Other class number assigned by LAC"
           },
           "8": {
+            "code": "8",
             "label": "Other call number assigned by the contributing library"
           },
           "9": {
+            "code": "9",
             "label": "Other class number assigned by the contributing library"
           }
         }
@@ -12784,12 +15277,15 @@
         "label": "Existence in NLM collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NLM"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NLM"
           }
         }
@@ -12798,27 +15294,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by NLM"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than NLM"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "No series involved"
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           },
           " ": {
-            "label": "No information provided [OBSOLETE]"
+            "code": " ",
+            "label": "No information provided [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -12985,12 +15487,15 @@
         "label": "Existence in NAL collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NAL"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NAL"
           }
         }
@@ -13114,15 +15619,17 @@
         "label": "Code source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "NAL subject category code list"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "undefined"
+            "code": " ",
+            "label": "undefined",
+            "deprecated": true
           }
         }
       },
@@ -13239,12 +15746,15 @@
         "label": "Type of edition",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Full"
           },
           "1": {
+            "code": "1",
             "label": "Abridged"
           }
         }
@@ -13332,21 +15842,26 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]"
+            "code": " ",
+            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           },
           "2": {
-            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -13354,18 +15869,17 @@
         "label": "Source of classification number",
         "codes": {
           " ": {
-            "label": "No information provided"
+            "code": " ",
+            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]",
+            "deprecated": true
           },
           "0": {
+            "code": "0",
             "label": "Assigned by LC"
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]"
           }
         }
       },
@@ -13376,9 +15890,8 @@
           "solr": "082a_ClassificationDdc"
         },
         "b": {
-          "label": "Item number",
-          "repeatable": false,
-          "solr": "082b_ClassificationDdc_itemPortion"
+          "label": "DDC number-abridged NST version (SE) [OBSOLETE]",
+          "deprecated": true
         },
         "m": {
           "label": "Standard or optional designation",
@@ -13431,11 +15944,6 @@
             "solr": "082x23_ClassificationDdc_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "DDC number-abridged NST version (SE) [OBSOLETE]"
-        }
       }
     },
     "083": {
@@ -13449,12 +15957,15 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
           }
         }
@@ -13745,24 +16256,23 @@
         "label": "Number source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Source specified in subfield $2"
           },
           "0": {
-            "label": "Superintendent of Documents Classification System"
+            "code": "0",
+            "label": "United States",
+            "deprecated": true
           },
           "1": {
-            "label": "Government of Canada Publications: Outline of Classification"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "United States"
-          },
-          "1": {
-            "label": "Canada"
+            "code": "1",
+            "label": "Canada",
+            "deprecated": true
           },
           "2-9": {
-            "label": "Reserved"
+            "code": "2-9",
+            "label": "Reserved",
+            "deprecated": true
           }
         }
       },
@@ -14144,12 +16654,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -14314,12 +16827,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -14474,12 +16990,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -14639,6 +17158,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -14792,9 +17312,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -14803,9 +17325,11 @@
         "label": "Type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Abbreviated key title"
           },
           "0": {
+            "code": "0",
             "label": "Other abbreviated title"
           }
         }
@@ -14876,24 +17400,28 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
-            "label": "No nonfiling characters"
+            "code": "0",
+            "label": "Key title is same as field 245 / No key title added entry; title proper same",
+            "deprecated": true
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "Key title is same as field 245 / No key title added entry; title proper same"
           },
           "1": {
-            "label": "Key title is not the same as field 245 / Key title added entry; title proper different"
+            "code": "1",
+            "label": "Key title is not the same as field 245 / Key title added entry; title proper different",
+            "deprecated": true
           },
           "2": {
-            "label": "Key title added entry; title proper same"
+            "code": "2",
+            "label": "Key title added entry; title proper same",
+            "deprecated": true
           },
           "3": {
-            "label": "No key title added entry; title proper different"
+            "code": "3",
+            "label": "No key title added entry; title proper different",
+            "deprecated": true
           }
         }
       },
@@ -14951,18 +17479,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -14970,6 +17502,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -15112,9 +17645,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -15123,9 +17658,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -15177,6 +17714,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2428_TitleTranslation_fieldLink"
+        },
+        "d": {
+          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
+        },
+        "e": {
+          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -15197,14 +17742,6 @@
             "solr": "242x23_TitleTranslation_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
-        },
-        "e": {
-          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
-        }
       }
     },
     "243": {
@@ -15218,18 +17755,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -15237,6 +17778,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -15350,9 +17892,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -15361,9 +17905,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -15434,6 +17980,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2458_Title_fieldLink"
+        },
+        "d": {
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
+        },
+        "e": {
+          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -15454,14 +18008,6 @@
             "solr": "245x23_Title_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
-        },
-        "e": {
-          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]"
-        }
       }
     },
     "246": {
@@ -15475,15 +18021,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "No note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -15492,33 +18042,43 @@
         "label": "Type of title",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Portion of title"
           },
           "1": {
+            "code": "1",
             "label": "Parallel title"
           },
           "2": {
+            "code": "2",
             "label": "Distinctive title"
           },
           "3": {
+            "code": "3",
             "label": "Other title"
           },
           "4": {
+            "code": "4",
             "label": "Cover title"
           },
           "5": {
+            "code": "5",
             "label": "Added title page title"
           },
           "6": {
+            "code": "6",
             "label": "Caption title"
           },
           "7": {
+            "code": "7",
             "label": "Running title"
           },
           "8": {
+            "code": "8",
             "label": "Spine title"
           }
         }
@@ -15585,6 +18145,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2468_ParallelTitle_fieldLink"
+        },
+        "c": {
+          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]",
+          "deprecated": true
+        },
+        "d": {
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
+        },
+        "e": {
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -15605,17 +18177,6 @@
             "solr": "246x23_ParallelTitle_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]"
-        },
-        "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
-        },
-        "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
-        }
       }
     },
     "247": {
@@ -15629,9 +18190,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -15640,9 +18203,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -15703,6 +18268,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2478_VariantTitle_fieldLink"
+        },
+        "d": {
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
+        },
+        "e": {
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
+        },
+        "c": {
+          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -15722,17 +18299,6 @@
             "repeatable": false,
             "solr": "247x23_VariantTitle_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
-        },
-        "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
-        },
-        "c": {
-          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]"
         }
       }
     },
@@ -16225,21 +18791,26 @@
         "label": "Sequence of publishing statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest available publisher"
           },
           "2": {
+            "code": "2",
             "label": "Intervening publisher"
           },
           "3": {
+            "code": "3",
             "label": "Current/latest publisher"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Publisher, distributor, etc. is present"
+            "code": "0",
+            "label": "Publisher, distributor, etc. is present",
+            "deprecated": true
           },
           "1": {
-            "label": "Publisher, distributor, etc. not present"
+            "code": "1",
+            "label": "Publisher, distributor, etc. not present",
+            "deprecated": true
           }
         }
       },
@@ -16290,6 +18861,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2608_Publication_fieldLink"
+        },
+        "d": {
+          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]",
+          "deprecated": true
+        },
+        "k": {
+          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
+        },
+        "l": {
+          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -16309,17 +18892,6 @@
             "repeatable": false,
             "solr": "260x23_Publication_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]"
-        },
-        "k": {
-          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]"
-        },
-        "l": {
-          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]"
         }
       }
     },
@@ -16381,12 +18953,15 @@
         "label": "Sequence of statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -16395,18 +18970,23 @@
         "label": "Function of entity",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Production"
           },
           "1": {
+            "code": "1",
             "label": "Publication"
           },
           "2": {
+            "code": "2",
             "label": "Distribution"
           },
           "3": {
+            "code": "3",
             "label": "Manufacture"
           },
           "4": {
+            "code": "4",
             "label": "Copyright notice date"
           }
         }
@@ -16480,12 +19060,15 @@
         "label": "Level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -16494,12 +19077,15 @@
         "label": "Type of address",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Mailing"
           },
           "7": {
+            "code": "7",
             "label": "Type specified in subfield $i"
           }
         }
@@ -16693,6 +19279,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "3008_PhysicalDescription_fieldLink"
+        },
+        "d": {
+          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
+        },
+        "m": {
+          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
+        },
+        "n": {
+          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -16712,17 +19310,6 @@
             "repeatable": false,
             "solr": "300x23_PhysicalDescription_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "d": {
-          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]"
-        },
-        "m": {
-          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
-        },
-        "n": {
-          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
         }
       }
     },
@@ -16784,9 +19371,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Hours"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17535,12 +20124,15 @@
         "label": "Application",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Adaptive features to access primary content"
           },
           "1": {
+            "code": "1",
             "label": "Adaptive features to access secondary content"
           }
         }
@@ -17632,9 +20224,11 @@
         "label": "Geospatial reference dimension",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Horizontal coordinate system"
           },
           "1": {
+            "code": "1",
             "label": "Vertical coordinate system"
           }
         }
@@ -17643,30 +20237,39 @@
         "label": "Geospatial reference method",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Geographic"
           },
           "1": {
+            "code": "1",
             "label": "Map projection"
           },
           "2": {
+            "code": "2",
             "label": "Grid coordinate system"
           },
           "3": {
+            "code": "3",
             "label": "Local planar"
           },
           "4": {
+            "code": "4",
             "label": "Local"
           },
           "5": {
+            "code": "5",
             "label": "Geodetic model"
           },
           "6": {
+            "code": "6",
             "label": "Altitude"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in $2"
           },
           "8": {
+            "code": "8",
             "label": "Depth"
           }
         }
@@ -18630,24 +21233,31 @@
         "label": "Controlled element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Document"
           },
           "1": {
+            "code": "1",
             "label": "Title"
           },
           "2": {
+            "code": "2",
             "label": "Abstract"
           },
           "3": {
+            "code": "3",
             "label": "Contents note"
           },
           "4": {
+            "code": "4",
             "label": "Author"
           },
           "5": {
+            "code": "5",
             "label": "Record"
           },
           "8": {
+            "code": "8",
             "label": "None of the above"
           }
         }
@@ -18806,12 +21416,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -18937,9 +21550,11 @@
         "label": "Format of date",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Formatted style"
           },
           "1": {
+            "code": "1",
             "label": "Unformatted note"
           }
         }
@@ -18999,12 +21614,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -19013,12 +21631,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -19152,12 +21773,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -19166,12 +21790,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -19582,9 +22209,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in $2"
           }
         }
@@ -19835,18 +22464,23 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Medium of performance"
           },
           "1": {
+            "code": "1",
             "label": "Partial medium of performance"
           },
           "2": {
+            "code": "2",
             "label": "Medium of performance of musical content of representative expression"
           },
           "3": {
+            "code": "3",
             "label": "Partial medium of performance of musical content of representative expression"
           }
         }
@@ -19855,12 +22489,15 @@
         "label": "Access control",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not intended for access"
           },
           "1": {
+            "code": "1",
             "label": "Intended for access"
           }
         }
@@ -20076,15 +22713,19 @@
         "label": "Key type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Relationship to original unknown"
           },
           "0": {
+            "code": "0",
             "label": "Original key"
           },
           "1": {
+            "code": "1",
             "label": "Transposed key"
           },
           "2": {
+            "code": "2",
             "label": "Key of representative expression"
           }
         }
@@ -20496,12 +23137,15 @@
         "label": "Type of time period",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Creation of work"
           },
           "2": {
+            "code": "2",
             "label": "Creation of aggregate work"
           }
         }
@@ -20589,12 +23233,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -20603,9 +23250,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -20735,12 +23384,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -20749,9 +23401,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -20881,12 +23535,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -20895,9 +23552,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "9": {
+            "code": "9",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -21028,9 +23687,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -21082,6 +23743,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "4408_SeriesStatementAddedEntryTitle_fieldLink"
+        },
+        "h": {
+          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -21102,11 +23767,6 @@
             "solr": "440x23_SeriesStatementAddedEntryTitle_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "h": {
-          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]"
-        }
       }
     },
     "490": {
@@ -21120,9 +23780,11 @@
         "label": "Series tracing policy",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Series not traced"
           },
           "1": {
+            "code": "1",
             "label": "Series traced"
           }
         }
@@ -21241,6 +23903,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5008_GeneralNote_fieldLink"
+        },
+        "l": {
+          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
+        },
+        "x": {
+          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
+        },
+        "z": {
+          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -21260,17 +23934,6 @@
             "repeatable": false,
             "solr": "500x23_GeneralNote_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "l": {
-          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]"
-        },
-        "x": {
-          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]"
-        },
-        "z": {
-          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -21558,15 +24221,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Contents"
           },
           "1": {
+            "code": "1",
             "label": "Incomplete contents"
           },
           "2": {
+            "code": "2",
             "label": "Partial contents"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -21575,9 +24242,11 @@
         "label": "Level of content designation",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Enhanced"
           }
         }
@@ -21656,12 +24325,15 @@
         "label": "Restriction",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No restrictions"
           },
           "1": {
+            "code": "1",
             "label": "Restrictions apply"
           }
         }
@@ -21893,18 +24565,23 @@
         "label": "Coverage/location in source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Coverage unknown"
           },
           "1": {
+            "code": "1",
             "label": "Coverage complete"
           },
           "2": {
+            "code": "2",
             "label": "Coverage is selective"
           },
           "3": {
+            "code": "3",
             "label": "Location in source not given"
           },
           "4": {
+            "code": "4",
             "label": "Location in source given"
           }
         }
@@ -21989,18 +24666,22 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No display constant generated"
           },
           "1": {
+            "code": "1",
             "label": "Cast"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Presenter (VM, MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Presenter (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Narrator (VM, MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Narrator (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -22237,6 +24918,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5158_NumberingPeculiarities_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -22257,11 +24942,6 @@
             "solr": "515x23_NumberingPeculiarities_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
-        }
       }
     },
     "516": {
@@ -22275,9 +24955,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Type of file"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22421,24 +25103,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Summary"
           },
           "0": {
+            "code": "0",
             "label": "Subject"
           },
           "1": {
+            "code": "1",
             "label": "Review"
           },
           "2": {
+            "code": "2",
             "label": "Scope and content"
           },
           "3": {
+            "code": "3",
             "label": "Abstract"
           },
           "4": {
+            "code": "4",
             "label": "Content advice"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22491,6 +25180,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5208_Summary_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -22518,11 +25211,6 @@
             "solr": "520x23_Summary_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]"
-        }
       }
     },
     "521": {
@@ -22536,24 +25224,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Audience"
           },
           "0": {
+            "code": "0",
             "label": "Reading grade level"
           },
           "1": {
+            "code": "1",
             "label": "Interest age level"
           },
           "2": {
+            "code": "2",
             "label": "Interest grade level"
           },
           "3": {
+            "code": "3",
             "label": "Special audience characteristics"
           },
           "4": {
+            "code": "4",
             "label": "Motivation/interest level"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22618,9 +25313,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Geographic coverage"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22675,9 +25372,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Cite as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22757,6 +25456,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5258_SupplementaryContent_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -22777,11 +25480,6 @@
             "solr": "525x23_SupplementaryContent_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
-        }
       }
     },
     "526": {
@@ -22795,9 +25493,11 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Reading program"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22927,6 +25627,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5308_AdditionalPhysicalFormAvailable_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -22947,11 +25651,6 @@
             "solr": "530x23_AdditionalPhysicalFormAvailable_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
-        }
       }
     },
     "532": {
@@ -22965,15 +25664,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Accessibility technical details"
           },
           "1": {
+            "code": "1",
             "label": "Accessibility features"
           },
           "2": {
+            "code": "2",
             "label": "Accessibility deficiencies"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22995,6 +25698,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5328_AccessibilityNote_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -23014,11 +25721,6 @@
             "repeatable": false,
             "solr": "532x23_AccessibilityNote_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -23381,18 +26083,22 @@
         "label": "Custodial role",
         "codes": {
           "1": {
+            "code": "1",
             "label": "Holder of originals"
           },
           "2": {
+            "code": "2",
             "label": "Holder of duplicates"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Repository (AM) [OBSOLETE, 1984]"
+            "code": "0",
+            "label": "Repository (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           },
           "3": {
-            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]"
+            "code": "3",
+            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           }
         }
       },
@@ -23640,9 +26346,11 @@
           "label": "The type of system control number",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Primary control number"
             },
             "1": {
+              "code": "1",
               "label": "Secondary control number"
             }
           }
@@ -23800,12 +26508,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -23910,12 +26621,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -24070,12 +26784,15 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Associated materials"
           },
           "1": {
+            "code": "1",
             "label": "Related materials"
           }
         }
@@ -24160,12 +26877,15 @@
         "label": "Type of data",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Biographical sketch"
           },
           "1": {
+            "code": "1",
             "label": "Administrative history"
           }
         }
@@ -24259,6 +26979,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5468_Language_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -24278,11 +27002,6 @@
             "repeatable": false,
             "solr": "546x23_Language_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -24311,6 +27030,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5478_FormerTitleComplexity_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -24330,11 +27053,6 @@
             "repeatable": false,
             "solr": "547x23_FormerTitleComplexity_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -24368,6 +27086,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5508_IssuingBody_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -24387,11 +27109,6 @@
             "repeatable": false,
             "solr": "550x23_IssuingBody_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -24538,12 +27255,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Indexes"
           },
           "0": {
+            "code": "0",
             "label": "Finding aids"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24628,9 +27348,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Documentation"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24690,12 +27412,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -24732,6 +27457,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5618_CustodialHistory_fieldLink"
+        },
+        "b": {
+          "label": "Time of collation (NR) [OBSOLETE, 1997]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -24751,11 +27480,6 @@
             "repeatable": false,
             "solr": "561x23_CustodialHistory_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Time of collation (NR) [OBSOLETE, 1997]"
         }
       }
     },
@@ -24909,12 +27633,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "File size"
           },
           "0": {
+            "code": "0",
             "label": "Case file characteristics"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24994,9 +27721,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Methodology"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25115,6 +27844,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5808_LinkingEntryComplexity_fieldLink"
+        },
+        "z": {
+          "label": "Source of note information [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -25142,11 +27875,6 @@
             "solr": "580x23_LinkingEntryComplexity_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "z": {
-          "label": "Source of note information [OBSOLETE, 1990]"
-        }
       }
     },
     "581": {
@@ -25160,9 +27888,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Publications"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25227,12 +27957,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -25502,9 +28235,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Awards"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25564,12 +28299,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Source of description"
           },
           "1": {
+            "code": "1",
             "label": "Latest issue consulted"
           }
         }
@@ -26030,18 +28768,21 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Multiple surname [OBSOLETE, 1996]"
+            "code": "2",
+            "label": "Multiple surname [OBSOLETE, 1996]",
+            "deprecated": true
           }
         }
       },
@@ -26049,27 +28790,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -26292,12 +29041,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -26306,27 +29058,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -26539,12 +29299,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -26553,27 +29316,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -26776,6 +29547,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -26784,27 +29556,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -26996,27 +29776,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -27141,27 +29929,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -27276,15 +30072,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -27293,27 +30093,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -27325,9 +30133,8 @@
           "solr": "650a_Topic_topicalTerm"
         },
         "b": {
-          "label": "Topical term following geographic name entry element",
-          "repeatable": false,
-          "solr": "650b_Topic_topicalTerm"
+          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]",
+          "deprecated": true
         },
         "c": {
           "label": "Location of event",
@@ -27446,11 +30253,6 @@
             "solr": "650x23_Topic_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]"
-        }
       }
     },
     "651": {
@@ -27465,27 +30267,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -27569,6 +30379,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "6518_Geographic_fieldLink"
+        },
+        "b": {
+          "label": "Geographic name following place entry element [OBSOLETE, 1981]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -27603,11 +30417,6 @@
             "solr": "651x23_Geographic_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Geographic name following place entry element [OBSOLETE, 1981]"
-        }
       }
     },
     "653": {
@@ -27621,15 +30430,19 @@
         "label": "Level of index term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -27638,27 +30451,35 @@
         "label": "Type of term or name",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Topical term"
           },
           "1": {
+            "code": "1",
             "label": "Personal name"
           },
           "2": {
+            "code": "2",
             "label": "Corporate name"
           },
           "3": {
+            "code": "3",
             "label": "Meeting name"
           },
           "4": {
+            "code": "4",
             "label": "Chronological term"
           },
           "5": {
+            "code": "5",
             "label": "Geographic name"
           },
           "6": {
+            "code": "6",
             "label": "Genre/form term"
           }
         }
@@ -27747,15 +30568,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -27882,9 +30707,11 @@
         "label": "Type of heading",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Faceted"
           }
         }
@@ -27893,27 +30720,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -28044,6 +30879,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -28159,6 +30995,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -28506,9 +31343,11 @@
         "label": "Source of name, title, or term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -28600,6 +31439,7 @@
         "label": "Nummer der RSWK-Kette",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Nummer der RSWK-Kette"
           }
         }
@@ -28608,9 +31448,11 @@
         "label": "Nummer des Kettengliedes",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Abschluss einer RSWK-Kettenfolge, Feld enthält dann zwei $5"
           },
           "0-9": {
+            "code": "0-9",
             "label": "Nummer des Kettengliedes"
           }
         }
@@ -28807,6 +31649,7 @@
           "label": "Provides information on the content of subfield $a",
           "codes": {
             "7": {
+              "code": "7",
               "label": "Source specified in subfield $2"
             }
           }
@@ -29121,12 +31964,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -29135,9 +31981,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -29353,12 +32201,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -29367,9 +32218,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -29575,12 +32428,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -29589,9 +32445,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -29810,12 +32668,15 @@
           "label": "Type of name",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Not specified"
             },
             "1": {
+              "code": "1",
               "label": "Personal"
             },
             "2": {
+              "code": "2",
               "label": "Other"
             }
           }
@@ -29903,6 +32764,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -29911,9 +32773,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -30087,15 +32951,17 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "Nonfiling characters not specified [OBSOLETE, 1980]"
+            "code": " ",
+            "label": "Nonfiling characters not specified [OBSOLETE, 1980]",
+            "deprecated": true
           }
         }
       },
@@ -30103,21 +32969,27 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]"
+            "code": "0",
+            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "1": {
-            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]"
+            "code": "1",
+            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Not printed on card [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Not printed on card [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -30688,9 +33560,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -30699,9 +33573,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Main series"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -30968,9 +33844,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -30979,9 +33857,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has subseries"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -31248,9 +34128,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -31259,9 +34141,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translation of"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -31555,9 +34439,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -31566,9 +34452,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translated as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -31855,9 +34743,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -31866,9 +34756,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has supplement"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -32155,9 +35047,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -32166,18 +35060,21 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Supplement to"
           },
           "0": {
+            "code": "0",
             "label": "Parent"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "1": {
-            "label": "Special issue [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "Special issue [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -32463,9 +35360,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -32474,9 +35373,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "In"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -32781,9 +35682,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -32792,15 +35695,17 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Constituent unit"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Includes [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Includes [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -33086,9 +35991,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -33097,21 +36004,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Other edition available"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Entry not the same"
+            "code": "0",
+            "label": "Entry not the same",
+            "deprecated": true
           },
           "1": {
-            "label": "Entry is the same as title"
+            "code": "1",
+            "label": "Entry is the same as title",
+            "deprecated": true
           },
           "2": {
-            "label": "Entry is the same as main entry and title"
+            "code": "2",
+            "label": "Entry is the same as main entry and title",
+            "deprecated": true
           }
         }
       },
@@ -33407,9 +36320,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -33418,9 +36333,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Available in another form"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -33707,9 +36624,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -33718,21 +36637,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Issued with"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Issued with [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Issued with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "1": {
-            "label": "With [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "With [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "2": {
-            "label": "Bound with [OBSOLETE] [CAN/MARC only]"
+            "code": "2",
+            "label": "Bound with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -34018,9 +36943,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -34029,27 +36956,35 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continues"
           },
           "1": {
+            "code": "1",
             "label": "Continues in part"
           },
           "2": {
+            "code": "2",
             "label": "Supersedes"
           },
           "3": {
+            "code": "3",
             "label": "Supersedes in part"
           },
           "4": {
+            "code": "4",
             "label": "Formed by the union of ... and ..."
           },
           "5": {
+            "code": "5",
             "label": "Absorbed"
           },
           "6": {
+            "code": "6",
             "label": "Absorbed in part"
           },
           "7": {
+            "code": "7",
             "label": "Separated from"
           }
         }
@@ -34337,9 +37272,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -34348,30 +37285,39 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continued by"
           },
           "1": {
+            "code": "1",
             "label": "Continued in part by"
           },
           "2": {
+            "code": "2",
             "label": "Superseded by"
           },
           "3": {
+            "code": "3",
             "label": "Superseded in part by"
           },
           "4": {
+            "code": "4",
             "label": "Absorbed by"
           },
           "5": {
+            "code": "5",
             "label": "Absorbed in part by"
           },
           "6": {
+            "code": "6",
             "label": "Split into ... and ..."
           },
           "7": {
+            "code": "7",
             "label": "Merged with ... to form ..."
           },
           "8": {
+            "code": "8",
             "label": "Changed back to"
           }
         }
@@ -34658,9 +37604,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -34669,9 +37617,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Data source"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -34973,9 +37923,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -34984,9 +37936,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Related item"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -35273,9 +38227,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -35284,9 +38240,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Parallel description in another language of cataloging"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -35423,12 +38381,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -35738,12 +38699,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -36036,12 +39000,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -36325,9 +39292,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -36661,6 +39630,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "8508_HeldBy_fieldLink"
+        },
+        "b": {
+          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
+        },
+        "d": {
+          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
+        },
+        "e": {
+          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -36680,17 +39661,6 @@
             "repeatable": false,
             "solr": "850x23_HeldBy_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]"
-        },
-        "d": {
-          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]"
-        },
-        "e": {
-          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]"
         }
       }
     },
@@ -36757,33 +39727,43 @@
         "label": "Shelving scheme",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Library of Congress classification"
           },
           "1": {
+            "code": "1",
             "label": "Dewey Decimal classification"
           },
           "2": {
+            "code": "2",
             "label": "National Library of Medicine classification"
           },
           "3": {
+            "code": "3",
             "label": "Superintendent of Documents classification"
           },
           "4": {
+            "code": "4",
             "label": "Shelving control number"
           },
           "5": {
+            "code": "5",
             "label": "Title"
           },
           "6": {
+            "code": "6",
             "label": "Shelved separately"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Other scheme"
           }
         }
@@ -36792,15 +39772,19 @@
         "label": "Shelving order",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not enumeration"
           },
           "1": {
+            "code": "1",
             "label": "Primary enumeration"
           },
           "2": {
+            "code": "2",
             "label": "Alternative enumeration"
           }
         }
@@ -36967,24 +39951,31 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Email"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "2": {
+            "code": "2",
             "label": "Remote login (Telnet)"
           },
           "3": {
+            "code": "3",
             "label": "Dial-up"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -36993,24 +39984,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -37042,19 +40040,16 @@
           "solr": "856f_ElectronicLocationAndAccess_name"
         },
         "g": {
-          "label": "Persistent identifier",
-          "repeatable": true,
-          "solr": "856g_ElectronicLocationAndAccess_pid"
+          "label": "Uniform Resource Name [OBSOLETE, 2000]",
+          "deprecated": true
         },
         "h": {
-          "label": "Non-functioning Uniform Resource Identifier",
-          "repeatable": true,
-          "solr": "856h_ElectronicLocationAndAccess_nonFunctioningURI"
+          "label": "Processor of request [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "l": {
-          "label": "Standardized information governing access",
-          "repeatable": true,
-          "solr": "856l_ElectronicLocationAndAccess_access"
+          "label": "Logon [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "m": {
           "label": "Contact for access assistance",
@@ -37062,9 +40057,8 @@
           "solr": "856m_ElectronicLocationAndAccess_contact"
         },
         "n": {
-          "label": "Terms governing access",
-          "repeatable": true,
-          "solr": "856n_ElectronicLocationAndAccess_terms"
+          "label": "Name of location of host [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "o": {
           "label": "Operating system",
@@ -37082,9 +40076,8 @@
           "solr": "856q_ElectronicLocationAndAccess_format"
         },
         "r": {
-          "label": "Standardized information governing use and reproduction",
-          "repeatable": true,
-          "solr": "856r_ElectronicLocationAndAccess_use"
+          "label": "Settings [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "s": {
           "label": "File size",
@@ -37092,9 +40085,8 @@
           "solr": "856s_ElectronicLocationAndAccess_fileSize"
         },
         "t": {
-          "label": "Terms governing use and reproduction",
-          "repeatable": true,
-          "solr": "856t_ElectronicLocationAndAccess_termsOfUse"
+          "label": "Terminal emulation [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "u": {
           "label": "Uniform Resource Identifier",
@@ -37153,6 +40145,22 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "8568_ElectronicLocationAndAccess_fieldLink"
+        },
+        "b": {
+          "label": "Access number [OBSOLETE, 2020]",
+          "deprecated": true
+        },
+        "i": {
+          "label": "Instruction [OBSOLETE, 2020]",
+          "deprecated": true
+        },
+        "j": {
+          "label": "Bits per second [OBSOLETE, 2020]",
+          "deprecated": true
+        },
+        "k": {
+          "label": "Password [OBSOLETE, 2020]",
+          "deprecated": true
         }
       },
       "versionSpecificSubfields": {
@@ -37185,38 +40193,6 @@
             "solr": "856x23_ElectronicLocationAndAccess_number_KBR"
           }
         }
-      },
-      "historical-subfields": {
-        "g": {
-          "label": "Uniform Resource Name [OBSOLETE, 2000]"
-        },
-        "b": {
-          "label": "Access number [OBSOLETE, 2020]"
-        },
-        "h": {
-          "label": "Processor of request [OBSOLETE, 2020]"
-        },
-        "i": {
-          "label": "Instruction [OBSOLETE, 2020]"
-        },
-        "j": {
-          "label": "Bits per second [OBSOLETE, 2020]"
-        },
-        "k": {
-          "label": "Password [OBSOLETE, 2020]"
-        },
-        "l": {
-          "label": "Logon [OBSOLETE, 2020]"
-        },
-        "n": {
-          "label": "Name of location of host [OBSOLETE, 2020]"
-        },
-        "r": {
-          "label": "Settings [OBSOLETE, 2020]"
-        },
-        "t": {
-          "label": "Terminal emulation [OBSOLETE, 2020]"
-        }
       }
     },
     "857": {
@@ -37230,15 +40206,19 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -37247,24 +40227,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -37447,15 +40434,19 @@
         "label": "Field encoding level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "3": {
+            "code": "3",
             "label": "Holdings level 3"
           },
           "4": {
+            "code": "4",
             "label": "Holdings level 4"
           },
           "5": {
+            "code": "5",
             "label": "Holdings level 4 with piece designation"
           }
         }
@@ -37464,15 +40455,19 @@
         "label": "Type of notation",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Non-standard"
           },
           "1": {
+            "code": "1",
             "label": "ANSI/NISO Z39.71 or ISO 10324"
           },
           "2": {
+            "code": "2",
             "label": "ANSI Z39.42"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -37928,15 +40923,19 @@
         "label": "Method of assignment",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided/not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Fully machine-generated"
           },
           "1": {
+            "code": "1",
             "label": "Partially machine-generated"
           },
           "2": {
+            "code": "2",
             "label": "Not machine-generated"
           }
         }
@@ -38186,12 +41185,15 @@
         "label": "Type of field",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Leader"
           },
           "1": {
+            "code": "1",
             "label": "Variable control fields (002-009)"
           },
           "2": {
+            "code": "2",
             "label": "Variable data fields (010-999)"
           }
         }
@@ -38214,14 +41216,12 @@
           "solr": "8862_ForeignMARCInformationField"
         },
         "c": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true,
-          "solr": "886c_ForeignMARCInformationField"
+          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "d": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true,
-          "solr": "886d_ForeignMARCInformationField"
+          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "e": {
           "label": "Foreign MARC subfield",
@@ -38396,14 +41396,6 @@
             "repeatable": false,
             "solr": "886x23_ForeignMARCInformationField_number_KBR"
           }
-        }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]"
-        },
-        "d": {
-          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]"
         }
       }
     },
@@ -39546,9 +42538,11 @@
           "label": "Art der Ressource",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Nicht-elektronisch"
             },
             "1": {
+              "code": "1",
               "label": "Elektronisch"
             }
           }
@@ -39732,12 +42726,15 @@
           "label": "First",
           "codes": {
             "p": {
+              "code": "p",
               "label": "Published on demand (bei Netzpublikationen"
             },
             "r": {
+              "code": "r",
               "label": "Reihenzugehörigkeit"
             },
             "s": {
+              "code": "s",
               "label": "Zugehörigkeit zu einer Sammlung"
             }
           }
@@ -39786,9 +42783,11 @@
           "label": "Level der Thema-Klassifikation",
           "codes": {
             "1": {
+              "code": "1",
               "label": "Primär (aus ONIX mainsubject)"
             },
             "2": {
+              "code": "2",
               "label": "Sekundär (aus ONIX subject)"
             }
           }
@@ -40352,9 +43351,11 @@
         "label": "Type of title",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Document Supply Shelving Title"
           },
           "1": {
+            "code": "1",
             "label": "DLS Ingest Title"
           }
         }
@@ -40796,24 +43797,31 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Email"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "2": {
+            "code": "2",
             "label": "Remote login (Telnet)"
           },
           "3": {
+            "code": "3",
             "label": "Dial-up"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -40822,18 +43830,23 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -40996,11 +44009,10 @@
           "label": "Aleph/ANL fulltext linkage",
           "repeatable": false,
           "solr": "9569_ElectronicLocationAndAccessTest"
-        }
-      },
-      "historical-subfields": {
+        },
         "g": {
-          "label": "Uniform Resource Name [OBSOLETE, 2000]"
+          "label": "Uniform Resource Name [OBSOLETE, 2000]",
+          "deprecated": true
         }
       }
     },
@@ -41081,9 +44093,11 @@
           "label": "Printing instruction",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Printing data"
             },
             "1": {
+              "code": "1",
               "label": "Non-printing data"
             }
           }
@@ -41167,6 +44181,7 @@
           "label": "Virtuaalikokoelma",
           "codes": {
             "8": {
+              "code": "8",
               "label": "Virtuaalikokoelma"
             }
           }
@@ -41765,12 +44780,15 @@
           "label": "Type of personal name entry element",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Forename"
             },
             "1": {
+              "code": "1",
               "label": "Surname"
             },
             "3": {
+              "code": "3",
               "label": "Family name"
             }
           }
@@ -41928,12 +44946,15 @@
           "label": "Type of corporate name entry element",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Inverted name"
             },
             "1": {
+              "code": "1",
               "label": "Jurisdiction name"
             },
             "2": {
+              "code": "2",
               "label": "Name in direct order"
             }
           }
@@ -41942,9 +44963,11 @@
           "label": "Type of added entry",
           "codes": {
             " ": {
+              "code": " ",
               "label": "No information provided"
             },
             "2": {
+              "code": "2",
               "label": "Analytical entry"
             }
           }
@@ -42505,12 +45528,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -42519,9 +45545,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -42699,12 +45727,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -42713,9 +45744,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -42883,12 +45916,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -42897,9 +45933,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -43549,12 +46587,15 @@
         "label": "Batch Upgrade Process",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Categories 1-3 (Legal Deposit/Purchased Print Monographs)"
           },
           "1": {
+            "code": "1",
             "label": "eBooks"
           },
           "2": {
+            "code": "2",
             "label": "Western European Print Monographs"
           }
         }
@@ -43584,12 +46625,15 @@
         "label": "Fee",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Current fee"
           },
           "1": {
+            "code": "1",
             "label": "Pending fee"
           },
           "2": {
+            "code": "2",
             "label": "Historical fee"
           }
         }
@@ -43872,6 +46916,7 @@
         "label": "Specifies whether series is traced",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Series not traced"
           }
         }
@@ -43977,6 +47022,7 @@
         "label": "Number of non-filing characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "0-9"
           }
         }
@@ -44123,9 +47169,11 @@
         "label": "Provides information on the content of subfield $a",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }

--- a/marc-schema/marc-schema-with-solr.json
+++ b/marc-schema/marc-schema-with-solr.json
@@ -24,18 +24,23 @@
           "solr": "leader05_recordStatus",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Increase in encoding level"
             },
             "c": {
+              "code": "c",
               "label": "Corrected or revised"
             },
             "d": {
+              "code": "d",
               "label": "Deleted"
             },
             "n": {
+              "code": "n",
               "label": "New"
             },
             "p": {
+              "code": "p",
               "label": "Increase in encoding level from prepublication"
             }
           }
@@ -49,57 +54,75 @@
           "solr": "leader06_typeOfRecord",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Language material"
             },
             "c": {
+              "code": "c",
               "label": "Notated music"
             },
             "d": {
+              "code": "d",
               "label": "Manuscript notated music"
             },
             "e": {
+              "code": "e",
               "label": "Cartographic material"
             },
             "f": {
+              "code": "f",
               "label": "Manuscript cartographic material"
             },
             "g": {
+              "code": "g",
               "label": "Projected medium"
             },
             "i": {
+              "code": "i",
               "label": "Nonmusical sound recording"
             },
             "j": {
+              "code": "j",
               "label": "Musical sound recording"
             },
             "k": {
+              "code": "k",
               "label": "Two-dimensional nonprojectable graphic"
             },
             "m": {
+              "code": "m",
               "label": "Computer file"
             },
             "o": {
+              "code": "o",
               "label": "Kit"
             },
             "p": {
+              "code": "p",
               "label": "Mixed materials"
             },
             "r": {
+              "code": "r",
               "label": "Three-dimensional artifact or naturally occurring object"
             },
             "t": {
+              "code": "t",
               "label": "Manuscript language material"
-            }
-          },
-          "historical-codes": {
+            },
             "b": {
-              "label": "Archival and manuscripts control [OBSOLETE, 1995]"
+              "code": "b",
+              "label": "Archival and manuscripts control [OBSOLETE, 1995]",
+              "deprecated": true
             },
             "h": {
-              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]"
+              "code": "h",
+              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]",
+              "deprecated": true
             },
             "n": {
-              "label": "Special instructional material"
+              "code": "n",
+              "label": "Special instructional material",
+              "deprecated": true
             }
           }
         },
@@ -112,30 +135,37 @@
           "solr": "leader07_bibliographicLevel",
           "codes": {
             "a": {
+              "code": "a",
               "label": "Monographic component part"
             },
             "b": {
+              "code": "b",
               "label": "Serial component part"
             },
             "c": {
+              "code": "c",
               "label": "Collection"
             },
             "d": {
+              "code": "d",
               "label": "Subunit"
             },
             "i": {
+              "code": "i",
               "label": "Integrating resource"
             },
             "m": {
+              "code": "m",
               "label": "Monograph/Item"
             },
             "s": {
+              "code": "s",
               "label": "Serial"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]"
+              "code": "p",
+              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -148,9 +178,11 @@
           "solr": "leader08_typeOfControl",
           "codes": {
             " ": {
+              "code": " ",
               "label": "No specified type"
             },
             "a": {
+              "code": "a",
               "label": "Archival"
             }
           }
@@ -164,9 +196,11 @@
           "solr": "leader09_characterCodingScheme",
           "codes": {
             " ": {
+              "code": " ",
               "label": "MARC-8"
             },
             "a": {
+              "code": "a",
               "label": "UCS/Unicode"
             }
           }
@@ -180,6 +214,7 @@
           "solr": "leader10_indicatorCount",
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for indicators"
             }
           }
@@ -193,6 +228,7 @@
           "solr": "leader11_subfieldCodeCount",
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for a subfield code"
             }
           }
@@ -214,42 +250,54 @@
           "solr": "leader17_encodingLevel",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Full level"
             },
             "1": {
+              "code": "1",
               "label": "Full level, material not examined"
             },
             "2": {
+              "code": "2",
               "label": "Less-than-full level, material not examined"
             },
             "3": {
+              "code": "3",
               "label": "Abbreviated level"
             },
             "4": {
+              "code": "4",
               "label": "Core level"
             },
             "5": {
+              "code": "5",
               "label": "Partial (preliminary) level"
             },
             "7": {
+              "code": "7",
               "label": "Minimal level"
             },
             "8": {
+              "code": "8",
               "label": "Prepublication level"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
             },
             "z": {
+              "code": "z",
               "label": "Not applicable"
-            }
-          },
-          "historical-codes": {
+            },
             "0": {
-              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "0",
+              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             },
             "6": {
-              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "6",
+              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -262,30 +310,38 @@
           "solr": "leader18_descriptiveCatalogingForm",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Non-ISBD"
             },
             "a": {
+              "code": "a",
               "label": "AACR 2"
             },
             "c": {
+              "code": "c",
               "label": "ISBD punctuation omitted"
             },
             "i": {
+              "code": "i",
               "label": "ISBD punctuation included"
             },
             "n": {
+              "code": "n",
               "label": "Non-ISBD punctuation omitted"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Record is in partial ISBD form [OBSOLETE, 1987]"
+              "code": "p",
+              "label": "Record is in partial ISBD form [OBSOLETE, 1987]",
+              "deprecated": true
             },
             "r": {
-              "label": "Record is in provisional form [OBSOLETE, 1981]"
+              "code": "r",
+              "label": "Record is in provisional form [OBSOLETE, 1981]",
+              "deprecated": true
             }
           }
         },
@@ -298,24 +354,30 @@
           "solr": "leader19_multipartResourceRecordLevel",
           "codes": {
             " ": {
+              "code": " ",
               "label": "Not specified or not applicable"
             },
             "a": {
+              "code": "a",
               "label": "Set"
             },
             "b": {
+              "code": "b",
               "label": "Part with independent title"
             },
             "c": {
+              "code": "c",
               "label": "Part with dependent title"
-            }
-          },
-          "historical-codes": {
+            },
             "r": {
-              "label": "Linked record requirement [OBSOLETE, 2007]"
+              "code": "r",
+              "label": "Linked record requirement [OBSOLETE, 2007]",
+              "deprecated": true
             },
             "2": {
-              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]"
+              "code": "2",
+              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -328,6 +390,7 @@
           "solr": "leader20_lengthOfTheLengthOfFieldPortion",
           "codes": {
             "4": {
+              "code": "4",
               "label": "Number of characters in the length-of-field portion of a Directory entry"
             }
           }
@@ -341,6 +404,7 @@
           "solr": "leader21_lengthOfTheStartingCharacterPositionPortion",
           "codes": {
             "5": {
+              "code": "5",
               "label": "Number of characters in the starting-character-position portion of a Directory entry"
             }
           }
@@ -354,6 +418,7 @@
           "solr": "leader22_lengthOfTheImplementationDefinedPortion",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Number of characters in the implementation-defined portion of a Directory entry"
             }
           }
@@ -367,6 +432,7 @@
           "solr": "leader23_undefined",
           "codes": {
             "0": {
+              "code": "0",
               "label": "Undefined"
             }
           }
@@ -407,48 +473,63 @@
               "solr": "006all00_AdditionalMaterialCharacteristics_formOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Language material"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Notated music"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Manuscript notated music"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cartographic material"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Manuscript cartographic material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected medium"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nonmusical sound recording"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Musical sound recording"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Two-dimensional nonprojectable graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Computer file"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Mixed materials"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Three-dimensional artifact or naturally occurring object"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Serial/Integrating resource"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Manuscript language material"
                 }
               }
@@ -467,54 +548,71 @@
               "solr": "006book01_AdditionalMaterialCharacteristics_illustrations",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -528,33 +626,43 @@
               "solr": "006book05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -568,36 +676,47 @@
               "solr": "006book06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -612,90 +731,119 @@
               "solr": "006book07_AdditionalMaterialCharacteristics_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -709,39 +857,51 @@
               "solr": "006book11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -755,12 +915,15 @@
               "solr": "006book12_AdditionalMaterialCharacteristics_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -774,12 +937,15 @@
               "solr": "006book13_AdditionalMaterialCharacteristics_festschrift",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -793,12 +959,15 @@
               "solr": "006book14_AdditionalMaterialCharacteristics_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -812,42 +981,55 @@
               "solr": "006book16_AdditionalMaterialCharacteristics_literaryForm",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -861,21 +1043,27 @@
               "solr": "006book17_AdditionalMaterialCharacteristics_biography",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -893,33 +1081,43 @@
               "solr": "006computer05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -933,15 +1131,19 @@
               "solr": "006computer06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -955,45 +1157,59 @@
               "solr": "006computer09_AdditionalMaterialCharacteristics_typeOfComputerFile",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1007,39 +1223,51 @@
               "solr": "006computer11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1057,63 +1285,83 @@
               "solr": "006continuing01_AdditionalMaterialCharacteristics_frequency",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1127,18 +1375,23 @@
               "solr": "006continuing02_AdditionalMaterialCharacteristics_regularity",
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1152,27 +1405,35 @@
               "solr": "006continuing04_AdditionalMaterialCharacteristics_typeOfContinuingResource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1186,36 +1447,47 @@
               "solr": "006continuing05_AdditionalMaterialCharacteristics_formOfOriginalItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1229,36 +1501,47 @@
               "solr": "006continuing06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1272,87 +1555,115 @@
               "solr": "006continuing07_AdditionalMaterialCharacteristics_natureOfEntireWork",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1367,87 +1678,115 @@
               "solr": "006continuing08_AdditionalMaterialCharacteristics_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1461,39 +1800,51 @@
               "solr": "006continuing11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1507,12 +1858,15 @@
               "solr": "006continuing12_AdditionalMaterialCharacteristics_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1526,51 +1880,67 @@
               "solr": "006continuing16_AdditionalMaterialCharacteristics_originalAlphabetOrScriptOfTitle",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1584,15 +1954,19 @@
               "solr": "006continuing17_AdditionalMaterialCharacteristics_entryConvention",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1611,45 +1985,59 @@
               "solr": "006map01_AdditionalMaterialCharacteristics_relief",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1663,147 +2051,195 @@
               "solr": "006map05_AdditionalMaterialCharacteristics_projection",
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -1817,33 +2253,43 @@
               "solr": "006map08_AdditionalMaterialCharacteristics_typeOfCartographicMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1857,39 +2303,51 @@
               "solr": "006map11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1903,36 +2361,47 @@
               "solr": "006map12_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1946,12 +2415,15 @@
               "solr": "006map14_AdditionalMaterialCharacteristics_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1966,36 +2438,47 @@
               "solr": "006map16_AdditionalMaterialCharacteristics_specialFormatCharacteristics",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2013,36 +2496,47 @@
               "solr": "006mixed06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2060,222 +2554,295 @@
               "solr": "006music01_AdditionalMaterialCharacteristics_formOfComposition",
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -2289,54 +2856,71 @@
               "solr": "006music03_AdditionalMaterialCharacteristics_formatOfMusic",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2350,24 +2934,31 @@
               "solr": "006music04_AdditionalMaterialCharacteristics_musicParts",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2381,33 +2972,43 @@
               "solr": "006music05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2421,36 +3022,47 @@
               "solr": "006music06_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2465,48 +3077,63 @@
               "solr": "006music07_AdditionalMaterialCharacteristics_accompanyingMatter",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Technical and/or historical information on instruments"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2521,69 +3148,91 @@
               "solr": "006music13_AdditionalMaterialCharacteristics_literaryTextForSoundRecordings",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2597,24 +3246,31 @@
               "solr": "006music16_AdditionalMaterialCharacteristics_transpositionAndArrangement",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2632,18 +3288,23 @@
               "solr": "006visual01_AdditionalMaterialCharacteristics_runningTime",
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -2657,33 +3318,43 @@
               "solr": "006visual05_AdditionalMaterialCharacteristics_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2697,39 +3368,51 @@
               "solr": "006visual11_AdditionalMaterialCharacteristics_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2743,36 +3426,47 @@
               "solr": "006visual12_AdditionalMaterialCharacteristics_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2786,66 +3480,87 @@
               "solr": "006visual16_AdditionalMaterialCharacteristics_typeOfVisualMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2859,24 +3574,31 @@
               "solr": "006visual17_AdditionalMaterialCharacteristics_technique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2901,48 +3623,63 @@
               "solr": "007common00_PhysicalDescription_categoryOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Map"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tactile material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected graphic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microform"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Nonprojected graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Notated music"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound recording"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Text"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Unspecified"
                 }
               }
@@ -2960,51 +3697,67 @@
               "solr": "007electro01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Tape cartridge"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Chip cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Computer optical disc cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer disc, type unspecified"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Computer disc cartridge, type unspecified"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tape cassette"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Tape reel"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magnetic disk"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Computer card"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Magneto-optical disc"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Optical disc"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Standalone device"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3018,36 +3771,45 @@
               "solr": "007electro03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Gray scale"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -3060,36 +3822,47 @@
               "solr": "007electro04_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 1/2 in."
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in."
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm."
                 },
                 "i": {
+                  "code": "i",
                   "label": "1 1/8 x 2 3/8 in."
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8 in."
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3103,15 +3876,19 @@
               "solr": "007electro05_PhysicalDescription_sound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3125,18 +3902,23 @@
               "solr": "007electro06_PhysicalDescription_imageBitDepth",
               "codes": {
                 "001-999": {
+                  "code": "001-999",
                   "label": "Exact bit depth"
                 },
                 "mmm": {
+                  "code": "mmm",
                   "label": "Multiple"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -3150,15 +3932,19 @@
               "solr": "007electro09_PhysicalDescription_fileFormats",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One file format"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple file formats"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3172,18 +3958,23 @@
               "solr": "007electro10_PhysicalDescription_qualityAssuranceTargets",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Absent"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Present"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3197,27 +3988,35 @@
               "solr": "007electro11_PhysicalDescription_antecedentOrSource",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "File reproduced from original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "File reproduced from microform"
                 },
                 "c": {
+                  "code": "c",
                   "label": "File reproduced from an electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "File reproduced from an intermediate (not microform)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3231,21 +4030,27 @@
               "solr": "007electro12_PhysicalDescription_levelOfCompression",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncompressed"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Lossless"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Lossy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3259,21 +4064,27 @@
               "solr": "007electro13_PhysicalDescription_reformattingQuality",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Access"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Preservation"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Replacement"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3291,30 +4102,37 @@
               "solr": "007globe01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Celestial globe"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Planetary or lunar globe"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Terrestrial globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Earth moon globe"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "d": {
-                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "d",
+                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -3327,18 +4145,21 @@
               "solr": "007globe03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3351,51 +4172,67 @@
               "solr": "007globe04_PhysicalDescription_physicalMedium",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3409,18 +4246,23 @@
               "solr": "007globe05_PhysicalDescription_typeOfReproduction",
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3438,9 +4280,11 @@
               "solr": "007kit01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3458,87 +4302,124 @@
               "solr": "007map01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Atlas"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Diagram"
                 },
                 "j": {
-                  "label": "Map"
+                  "code": "j",
+                  "label": "Orthophoto",
+                  "deprecated": true
                 },
                 "k": {
+                  "code": "k",
                   "label": "Profile"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Section"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "y": {
+                  "code": "y",
                   "label": "View"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Aerial chart"
+                  "code": "a",
+                  "label": "Aerial chart",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Aerial remote-sensing image"
+                  "code": "b",
+                  "label": "Aerial remote-sensing image",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Anamorphic map"
+                  "code": "c",
+                  "label": "Anamorphic map",
+                  "deprecated": true
                 },
                 "e": {
-                  "label": "Celestial chart"
+                  "code": "e",
+                  "label": "Celestial chart",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Chart"
+                  "code": "f",
+                  "label": "Chart",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Hydrographic chart"
+                  "code": "h",
+                  "label": "Hydrographic chart",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Imaginative map"
-                },
-                "j": {
-                  "label": "Orthophoto"
+                  "code": "i",
+                  "label": "Imaginative map",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Photo mosaic (controlled)"
+                  "code": "m",
+                  "label": "Photo mosaic (controlled)",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Photo mosaic (uncontrolled)"
+                  "code": "n",
+                  "label": "Photo mosaic (uncontrolled)",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Photomap"
+                  "code": "o",
+                  "label": "Photomap",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Plan"
+                  "code": "p",
+                  "label": "Plan",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Space remote-sensing image"
+                  "code": "t",
+                  "label": "Space remote-sensing image",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "Terrestrial remote-sensing image"
+                  "code": "v",
+                  "label": "Terrestrial remote-sensing image",
+                  "deprecated": true
                 },
                 "w": {
-                  "label": "Topographical drawing"
+                  "code": "w",
+                  "label": "Topographical drawing",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Topographical print"
+                  "code": "x",
+                  "label": "Topographical print",
+                  "deprecated": true
                 }
               }
             },
@@ -3551,18 +4432,21 @@
               "solr": "007map03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3575,72 +4459,95 @@
               "solr": "007map04_PhysicalDescription_physicalMedium",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Glass"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Flexible base photographic, positive"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Flexible base photographic, negative"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Non-flexible base photographic, positive"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Non-flexible base photographic, negative"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Not Applicable"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Other photographic medium"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3654,18 +4561,23 @@
               "solr": "007map05_PhysicalDescription_typeOfReproduction",
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3679,24 +4591,31 @@
               "solr": "007map06_PhysicalDescription_productionOrReproductionDetails",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Photocopy, blueline print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Photocopy"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Photographic pre-production"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Film"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3710,24 +4629,29 @@
               "solr": "007map07_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -3744,39 +4668,51 @@
               "solr": "007microform01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Aperture card"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfilm cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microfilm cassette"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Microfilm reel"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Microfiche"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Microfiche cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Microopaque"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microfilm slip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Microfilm roll"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3790,18 +4726,23 @@
               "solr": "007microform03_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3815,39 +4756,51 @@
               "solr": "007microform04_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "h": {
+                  "code": "h",
                   "label": "105 mm."
                 },
                 "l": {
+                  "code": "l",
                   "label": "3x5 in. or 8x13 cm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "4x6 in. or 11x15 cm."
                 },
                 "o": {
+                  "code": "o",
                   "label": "6x9 in. or 16x23 cm."
                 },
                 "p": {
+                  "code": "p",
                   "label": "3 1/4 x 7 3/8 in. or 9x19 cm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3861,27 +4814,35 @@
               "solr": "007microform05_PhysicalDescription_reductionRatioRange",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low reduction ratio"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Normal reduction"
                 },
                 "c": {
+                  "code": "c",
                   "label": "High reduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Very high reduction"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Ultra high reduction"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Reduction rate varies"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3903,21 +4864,27 @@
               "solr": "007microform09_PhysicalDescription_color",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3931,27 +4898,35 @@
               "solr": "007microform10_PhysicalDescription_emulsionOnFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Silver halide"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Diazo"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vesicular"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed emulsion"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3965,21 +4940,27 @@
               "solr": "007microform11_PhysicalDescription_generation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "First generation (master)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Printing master"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Service copy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed generation"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3993,45 +4974,57 @@
               "solr": "007microform12_PhysicalDescription_baseOfFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Not safety base [OBSOLETE, 1991]"
+                  "code": "b",
+                  "label": "Not safety base [OBSOLETE, 1991]",
+                  "deprecated": true
                 }
               }
             }
@@ -4048,24 +5041,31 @@
               "solr": "007motionPicture01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Film cartridge"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Film cassette"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Film roll"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Film reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4079,27 +5079,35 @@
               "solr": "007motionPicture03_PhysicalDescription_color",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4113,36 +5121,45 @@
               "solr": "007motionPicture04_PhysicalDescription_motionPicturePresentationFormat",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard sound aperture (reduced frame)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nonanamorphic (wide-screen)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "3D"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Anamorphic (wide-screen)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Other wide-screen format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Standard silent aperture (full frame)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1983]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1983]",
+                  "deprecated": true
                 }
               }
             },
@@ -4155,18 +5172,23 @@
               "solr": "007motionPicture05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4180,42 +5202,55 @@
               "solr": "007motionPicture06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Optical and magnetic sound track on motion picture film"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4229,33 +5264,43 @@
               "solr": "007motionPicture07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm."
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm."
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4269,27 +5314,35 @@
               "solr": "007motionPicture08_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4303,39 +5356,49 @@
               "solr": "007motionPicture09_PhysicalDescription_productionElements",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Workprint"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Trims"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Outtakes"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Rushes"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Mixing tracks"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Title bands/inter-title rolls"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Production rolls"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Other [OBSOLETE, 1988]"
+                  "code": "h",
+                  "label": "Other [OBSOLETE, 1988]",
+                  "deprecated": true
                 }
               }
             },
@@ -4348,21 +5411,27 @@
               "solr": "007motionPicture10_PhysicalDescription_positiveNegativeAspect",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4376,24 +5445,31 @@
               "solr": "007motionPicture11_PhysicalDescription_generation",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Duplicate"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Master"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Original"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reference print/viewing copy"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4407,39 +5483,51 @@
               "solr": "007motionPicture12_PhysicalDescription_baseOfFilm",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4453,72 +5541,95 @@
               "solr": "007motionPicture13_PhysicalDescription_refinedCategoriesOfColor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 layer color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "2 color, single strip"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Undetermined 2 color"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Undetermined 3 color"
                 },
                 "e": {
+                  "code": "e",
                   "label": "3 strip color"
                 },
                 "f": {
+                  "code": "f",
                   "label": "2 strip color"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Red strip"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blue or green strip"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Cyan strip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magenta strip"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Yellow strip"
                 },
                 "l": {
+                  "code": "l",
                   "label": "S E N 2"
                 },
                 "m": {
+                  "code": "m",
                   "label": "S E N 3"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Sepia tone"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Other tone"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Tint"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Tinted and toned"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Stencil color"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Hand colored"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4532,27 +5643,35 @@
               "solr": "007motionPicture14_PhysicalDescription_kindOfColorStockOrPrint",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Imbibition dye transfer prints"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Three-layer stock"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Three layer stock, low fade"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Duplitized stock"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4566,39 +5685,51 @@
               "solr": "007motionPicture15_PhysicalDescription_deteriorationStage",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "None apparent"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nitrate: suspicious odor"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Nitrate: pungent odor"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Nitrate: brownish, discoloration, fading, dusty"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Nitrate: sticky"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Nitrate: frothy, bubbles, blisters"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Nitrate: congealed"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Nitrate: powder"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Non-nitrate: detectable deterioration"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Non-nitrate: advanced deterioration"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Non-nitrate: disaster"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4612,18 +5743,23 @@
               "solr": "007motionPicture16_PhysicalDescription_completeness",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Complete"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Incomplete"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4649,66 +5785,87 @@
               "solr": "007nonprojected01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Activity card"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drawing"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Painting"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Photomechanical print"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Photonegative"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Photoprint"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Print"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Poster"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Postcard"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Icon"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Radiograph"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Study print"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Photograph, type unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4722,27 +5879,35 @@
               "solr": "007nonprojected03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4756,72 +5921,95 @@
               "solr": "007nonprojected04_PhysicalDescription_primarySupportMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4835,75 +6023,99 @@
               "solr": "007nonprojected05_PhysicalDescription_secondarySupportMaterial",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4921,9 +6133,11 @@
               "solr": "007music01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4941,39 +6155,50 @@
               "solr": "007projected01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Filmstrip cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Filmslip"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip, type unspecified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Filmstrip roll"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -4986,30 +6211,39 @@
               "solr": "007projected03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5023,39 +6257,50 @@
               "solr": "007projected04_PhysicalDescription_baseOfEmulsion",
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Safety film"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Film base, other than safety film"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -5068,18 +6313,23 @@
               "solr": "007projected05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5093,48 +6343,57 @@
               "solr": "007projected06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1981]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1981]"
                 }
               }
             },
@@ -5147,66 +6406,78 @@
               "solr": "007projected07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm. film width"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm. film width"
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm. film width"
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm. film width"
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm. film width"
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm. film width"
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm. film width"
                 },
                 "j": {
+                  "code": "j",
                   "label": "2x2 in. or 5x5 cm. slide"
                 },
                 "k": {
+                  "code": "k",
                   "label": "2 1/4 x 2 1/4 in. or 6x6 cm. slide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "4x5 in. or 10x13 cm. transparency"
                 },
                 "t": {
+                  "code": "t",
                   "label": "5x7 in. or 13x18 cm. transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8x10 in. or 21x26 cm. transparency"
                 },
                 "w": {
+                  "code": "w",
                   "label": "9x9 in. or 23x23 cm. transparency"
                 },
                 "x": {
+                  "code": "x",
                   "label": "10x10 in. or 26x26 cm. transparency"
                 },
                 "y": {
-                  "label": "7x7 in. or 18x18 cm. transparency"
+                  "code": "y",
+                  "label": "Unknown [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "u": {
-                  "label": "Unknown"
+                  "code": "u",
+                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "u": {
-                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]"
-                },
-                "y": {
-                  "label": "Unknown [OBSOLETE, 1980]"
                 }
               }
             },
@@ -5219,36 +6490,47 @@
               "solr": "007projected08_PhysicalDescription_secondarySupportMaterial",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Metal and glass"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Synthetic and glass"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5266,15 +6548,17 @@
               "solr": "007remoteSensing01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "No type specified [OBSOLETE, 1998]"
+                  "code": " ",
+                  "label": "No type specified [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             },
@@ -5287,24 +6571,31 @@
               "solr": "007remoteSensing03_PhysicalDescription_altitudeOfSensor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Surface"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Airborne"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Spaceborne"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5318,21 +6609,27 @@
               "solr": "007remoteSensing04_PhysicalDescription_attitudeOfSensor",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low oblique"
                 },
                 "b": {
+                  "code": "b",
                   "label": "High oblique"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vertical"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5346,42 +6643,55 @@
               "solr": "007remoteSensing05_PhysicalDescription_cloudCover",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "0-9%"
                 },
                 "1": {
+                  "code": "1",
                   "label": "10-19%"
                 },
                 "2": {
+                  "code": "2",
                   "label": "20-29%"
                 },
                 "3": {
+                  "code": "3",
                   "label": "30-39%"
                 },
                 "4": {
+                  "code": "4",
                   "label": "40-49%"
                 },
                 "5": {
+                  "code": "5",
                   "label": "50-59%"
                 },
                 "6": {
+                  "code": "6",
                   "label": "60-69%"
                 },
                 "7": {
+                  "code": "7",
                   "label": "70-79%"
                 },
                 "8": {
+                  "code": "8",
                   "label": "80-89%"
                 },
                 "9": {
+                  "code": "9",
                   "label": "90-100%"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5395,42 +6705,55 @@
               "solr": "007remoteSensing06_PhysicalDescription_platformConstructionType",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Balloon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Aircraft--low altitude"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Aircraft--medium altitude"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Aircraft--high altitude"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manned spacecraft"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Unmanned spacecraft"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Land-based remote-sensing device"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Water surface-based remote-sensing device"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Submersible remote-sensing device"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5444,27 +6767,35 @@
               "solr": "007remoteSensing07_PhysicalDescription_platformUseCategory",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Meteorological"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Surface observing"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Space observing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed uses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5478,18 +6809,23 @@
               "solr": "007remoteSensing08_PhysicalDescription_sensorType",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Active"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Passive"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5503,129 +6839,171 @@
               "solr": "007remoteSensing09_PhysicalDescription_dataType",
               "codes": {
                 "aa": {
+                  "code": "aa",
                   "label": "Visible light"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Near infrared"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Middle infrared"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Far infrared"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Thermal infrared"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Shortwave infrared (SWIR)"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Reflective infrared"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Combinations"
                 },
                 "dz": {
+                  "code": "dz",
                   "label": "Other infrared data"
                 },
                 "ga": {
+                  "code": "ga",
                   "label": "Sidelooking airborne radar (SLAR)"
                 },
                 "gb": {
+                  "code": "gb",
                   "label": "Synthetic aperture radar (SAR)-Single frequency"
                 },
                 "gc": {
+                  "code": "gc",
                   "label": "SAR-multi-frequency (multichannel)"
                 },
                 "gd": {
+                  "code": "gd",
                   "label": "SAR-like polarization"
                 },
                 "ge": {
+                  "code": "ge",
                   "label": "SAR-cross polarization"
                 },
                 "gf": {
+                  "code": "gf",
                   "label": "Infometric SAR"
                 },
                 "gg": {
+                  "code": "gg",
                   "label": "polarmetric SAR"
                 },
                 "gu": {
+                  "code": "gu",
                   "label": "Passive microwave mapping"
                 },
                 "gz": {
+                  "code": "gz",
                   "label": "Other microwave data"
                 },
                 "ja": {
+                  "code": "ja",
                   "label": "Far ultraviolet"
                 },
                 "jb": {
+                  "code": "jb",
                   "label": "Middle ultraviolet"
                 },
                 "jc": {
+                  "code": "jc",
                   "label": "Near ultraviolet"
                 },
                 "jv": {
+                  "code": "jv",
                   "label": "Ultraviolet combinations"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Other ultraviolet data"
                 },
                 "ma": {
+                  "code": "ma",
                   "label": "Multi-spectral, multidata"
                 },
                 "mb": {
+                  "code": "mb",
                   "label": "Multi-temporal"
                 },
                 "mm": {
+                  "code": "mm",
                   "label": "Combination of various data types"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "pa": {
+                  "code": "pa",
                   "label": "Sonar--water depth"
                 },
                 "pb": {
+                  "code": "pb",
                   "label": "Sonar--bottom topography images, sidescan"
                 },
                 "pc": {
+                  "code": "pc",
                   "label": "Sonar--bottom topography, near-surface"
                 },
                 "pd": {
+                  "code": "pd",
                   "label": "Sonar--bottom topography, near-bottom"
                 },
                 "pe": {
+                  "code": "pe",
                   "label": "Seismic surveys"
                 },
                 "pz": {
+                  "code": "pz",
                   "label": "Other acoustical data"
                 },
                 "ra": {
+                  "code": "ra",
                   "label": "Gravity anomalies (general)"
                 },
                 "rb": {
+                  "code": "rb",
                   "label": "Free-air"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Bouger"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Isostatic"
                 },
                 "sa": {
+                  "code": "sa",
                   "label": "Magnetic field"
                 },
                 "ta": {
+                  "code": "ta",
                   "label": "radiometric surveys"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -5643,54 +7021,67 @@
               "solr": "007soundRecording01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Belt"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cylinder"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Sound cartridge"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Sound-track film"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Roll"
                 },
                 "r": {
-                  "label": "Remote"
+                  "code": "r",
+                  "label": "Roll [OBSOLETE]",
+                  "deprecated": true
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound cassette"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Sound-tape reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wire recording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "c": {
-                  "label": "Cylinder [OBSOLETE]"
+                  "code": "c",
+                  "label": "Cylinder [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Sound-track film [OBSOLETE]"
-                },
-                "r": {
-                  "label": "Roll [OBSOLETE]"
+                  "code": "f",
+                  "label": "Sound-track film [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5703,57 +7094,75 @@
               "solr": "007soundRecording03_PhysicalDescription_speed",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "16 rpm (discs)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "33 1/3 rpm (discs)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "45 rpm (discs)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "78 rpm (discs)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "8 rpm (discs)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "1.4 m. per second (discs)"
                 },
                 "h": {
+                  "code": "h",
                   "label": "120 rpm (cylinders)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "160 rpm (cylinders)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "15/16 ips (tapes)"
                 },
                 "l": {
+                  "code": "l",
                   "label": "1 7/8 ips (tapes)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "3 3/4 ips (tapes)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "7 1/2 ips (tapes)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "15 ips (tapes)"
                 },
                 "r": {
+                  "code": "r",
                   "label": "30 ips (tape)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5767,42 +7176,58 @@
               "solr": "007soundRecording04_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Acoustic [OBSOLETE]"
+                  "code": "a",
+                  "label": "Acoustic [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Monaural (digital) [OBSOLETE]"
+                  "code": "f",
+                  "label": "Monaural (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Quadraphonic (digital) [OBSOLETE]"
+                  "code": "g",
+                  "label": "Quadraphonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Stereophonic (digital) [OBSOLETE]"
+                  "code": "j",
+                  "label": "Stereophonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Other (digital) [OBSOLETE]"
+                  "code": "k",
+                  "label": "Other (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other (electric) [OBSOLETE]"
+                  "code": "o",
+                  "label": "Other (electric) [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5815,21 +7240,27 @@
               "solr": "007soundRecording05_PhysicalDescription_grooveWidthOrGroovePitch",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Microgroove/fine"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Coarse/standard"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5843,45 +7274,59 @@
               "solr": "007soundRecording06_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 in. diameter"
                 },
                 "b": {
+                  "code": "b",
                   "label": "5 in. diameter"
                 },
                 "c": {
+                  "code": "c",
                   "label": "7 in. diameter"
                 },
                 "d": {
+                  "code": "d",
                   "label": "10 in. diameter"
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in. diameter"
                 },
                 "f": {
+                  "code": "f",
                   "label": "16 in. diameter"
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm. diameter"
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 x 3 7/8 in."
                 },
                 "s": {
+                  "code": "s",
                   "label": "2 3/4 x 4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5895,39 +7340,51 @@
               "solr": "007soundRecording07_PhysicalDescription_tapeWidth",
               "codes": {
                 "l": {
+                  "code": "l",
                   "label": "1/8 in."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "1/4 in. [OBSOLETE]"
+                  "code": "a",
+                  "label": "1/4 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "1/2 in. [OBSOLETE]"
+                  "code": "b",
+                  "label": "1/2 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "1 in. [OBSOLETE]"
+                  "code": "c",
+                  "label": "1 in. [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5940,33 +7397,43 @@
               "solr": "007soundRecording08_PhysicalDescription_tapeConfiguration",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full (1) track"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Half (2) track"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Quarter (4) track"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Eight track"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Twelve track"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Sixteen track"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5980,39 +7447,51 @@
               "solr": "007soundRecording09_PhysicalDescription_kindOfDiscCylinderOrTape",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Master tape"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Tape duplication master"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Disc master (negative)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instantaneous (recorded on the spot)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mass-produced"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Mother (positive)"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stamper (negative)"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Test pressing"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6026,48 +7505,63 @@
               "solr": "007soundRecording10_PhysicalDescription_kindOfMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Lacquer coating"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Cellulose nitrate"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Acetate tape with ferrous oxide"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Glass with lacquer"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Aluminum with lacquer"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Metal"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Plastic with metal"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plastic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Paper with lacquer or ferrous oxide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shellac"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wax"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6081,18 +7575,23 @@
               "solr": "007soundRecording11_PhysicalDescription_kindOfCutting",
               "codes": {
                 "h": {
+                  "code": "h",
                   "label": "Hill-and-dale cutting"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lateral or combined cutting"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6106,39 +7605,51 @@
               "solr": "007soundRecording12_PhysicalDescription_specialPlaybackCharacteristics",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "NAB standard"
                 },
                 "b": {
+                  "code": "b",
                   "label": "CCIR standard"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Dolby-B encoded"
                 },
                 "d": {
+                  "code": "d",
                   "label": "dbx encoded"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Digital recording"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Dolby-A encoded"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Dolby-C encoded"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CX encoded"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6152,24 +7663,31 @@
               "solr": "007soundRecording13_PhysicalDescription_captureAndStorageTechnique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Acoustical capture, analog direct storage"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Electrical capture, analog direct storage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Electrical capture, digital storage"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Electrical capture, analog electrical storage"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown capture and storage"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6187,24 +7705,31 @@
               "solr": "007tactile01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Moon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Combination"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Tactile, with no writing system"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6219,36 +7744,47 @@
               "solr": "007tactile03_PhysicalDescription_classOfBrailleWriting",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified class of braille writing"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Literary braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Format code braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Mathematics and scientific braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer braille"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Music braille"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple braille types"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6262,24 +7798,31 @@
               "solr": "007tactile05_PhysicalDescription_levelOfContraction",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncontracted"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Contracted"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6294,54 +7837,71 @@
               "solr": "007tactile06_PhysicalDescription_brailleMusicFormat",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified braille music format"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Bar over bar"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bar by bar"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Line over line"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Paragraph"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Single line"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Section by section"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Line by line"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Open score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Spanner short form scoring"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short form scoring"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Outline"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vertical score"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6355,21 +7915,27 @@
               "solr": "007tactile09_PhysicalDescription_specialPhysicalCharacteristics",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Print/braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Jumbo or enlarged braille"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6387,24 +7953,31 @@
               "solr": "007text01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Regular print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Large print"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Loose-leaf"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6422,15 +7995,19 @@
               "solr": "007unspecified01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Multiple physical forms"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6448,33 +8025,42 @@
               "solr": "007video01_PhysicalDescription_specificMaterialDesignation",
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Videocartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Videodisc"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Videocassette"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Videoreel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6487,27 +8073,35 @@
               "solr": "007video03_PhysicalDescription_color",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6521,72 +8115,94 @@
               "solr": "007video04_PhysicalDescription_videorecordingFormat",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Beta (1/2 in., videocassette)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "VHS (1/2 in., videocassette)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "U-matic (3/4 in., videocasstte)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "EIAJ (1/2 in., reel)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Type C (1 in., reel)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Quadruplex (1 in. or 2 in., reel)"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Laserdisc"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CED (Capacitance Electronic Disc) videodisc"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Betacam (1/2 in., videocassette)"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Betacam SP (1/2 in., videocassette)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Super-VHS (1/2 in., videocassette)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "M-II (1/2 in., videocassette)"
                 },
                 "o": {
+                  "code": "o",
                   "label": "D-2 (3/4 in., videocassette)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "8 mm."
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hi-8 mm."
                 },
                 "s": {
+                  "code": "s",
                   "label": "Blu-ray disc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "DVD"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6599,18 +8215,23 @@
               "solr": "007video05_PhysicalDescription_soundOnMediumOrSeparate",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6624,48 +8245,57 @@
               "solr": "007video06_PhysicalDescription_mediumForSound",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1980]"
                 }
               }
             },
@@ -6678,36 +8308,45 @@
               "solr": "007video07_PhysicalDescription_dimensions",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "q": {
+                  "code": "q",
                   "label": "2 in."
                 },
                 "r": {
+                  "code": "r",
                   "label": "3/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "1/4 in. [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "1/4 in. [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6720,27 +8359,35 @@
               "solr": "007video08_PhysicalDescription_configurationOfPlaybackChannels",
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6773,48 +8420,63 @@
               "solr": "008all06_GeneralInformation_typeOfDateOrPublicationStatus",
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "No dates given; B.C. date involved"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Continuing resource currently published"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Continuing resource ceased publication"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Detailed date"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Inclusive dates of collection"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Range of years of bulk of collection"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple dates"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Dates unknown"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Date of distribution/release/issue and production/recording session when different"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Questionable date"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reprint/reissue date and original date"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Single known date/probable date"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Publication date and copyright date"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Continuing resource status unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6860,30 +8522,37 @@
               "solr": "008all38_GeneralInformation_modifiedRecord",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not modified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dashed-on information omitted"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Completely romanized/printed cards romanized"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Completely romanized/printed cards in script"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shortened"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Missing characters"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -6896,39 +8565,54 @@
               "solr": "008all39_GeneralInformation_catalogingSource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "National bibliographic agency"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cooperative cataloging program"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Other"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]"
+                  "code": "a",
+                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]"
+                  "code": "b",
+                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "l",
+                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "o",
+                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]"
+                  "code": "n",
+                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -6946,54 +8630,71 @@
               "solr": "008book18_GeneralInformation_illustrations",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7007,42 +8708,54 @@
               "solr": "008book22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -7055,51 +8768,68 @@
               "solr": "008book23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -7113,105 +8843,140 @@
               "solr": "008book24_GeneralInformation_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Handbooks [OBSOLETE]"
+                  "code": "h",
+                  "label": "Handbooks [OBSOLETE]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Technical reports [OBSOLETE, 1997]"
+                  "code": "x",
+                  "label": "Technical reports [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7224,45 +8989,57 @@
               "solr": "008book28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -7275,12 +9052,15 @@
               "solr": "008book29_GeneralInformation_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7294,12 +9074,15 @@
               "solr": "008book30_GeneralInformation_festschrift",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7313,12 +9096,15 @@
               "solr": "008book31_GeneralInformation_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7332,51 +9118,66 @@
               "solr": "008book33_GeneralInformation_literaryForm",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Non-fiction [OBSOLETE, 1997]"
+                  "code": " ",
+                  "label": "Non-fiction [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Comic strips [OBSOLETE, 2008]"
+                  "code": "c",
+                  "label": "Comic strips [OBSOLETE, 2008]",
+                  "deprecated": true
                 }
               }
             },
@@ -7389,21 +9190,27 @@
               "solr": "008book34_GeneralInformation_biography",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7421,33 +9228,43 @@
               "solr": "008computer22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7461,15 +9278,19 @@
               "solr": "008computer23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7483,45 +9304,59 @@
               "solr": "008computer26_GeneralInformation_typeOfComputerFile",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7535,39 +9370,51 @@
               "solr": "008computer28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7585,63 +9432,83 @@
               "solr": "008continuing18_GeneralInformation_frequency",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7655,18 +9522,23 @@
               "solr": "008continuing19_GeneralInformation_regularity",
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7680,45 +9552,59 @@
               "solr": "008continuing21_GeneralInformation_typeOfContinuingResource",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Magazine"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blog"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Journal"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Repository"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Newsletter"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Directory"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7732,36 +9618,47 @@
               "solr": "008continuing22_GeneralInformation_formOfOriginalItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7775,51 +9672,68 @@
               "solr": "008continuing23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -7832,96 +9746,126 @@
               "solr": "008continuing24_GeneralInformation_natureOfEntireWork",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7935,96 +9879,126 @@
               "solr": "008continuing25_GeneralInformation_natureOfContents",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -8037,45 +10011,57 @@
               "solr": "008continuing28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -8088,12 +10074,15 @@
               "solr": "008continuing29_GeneralInformation_conferencePublication",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8107,51 +10096,67 @@
               "solr": "008continuing33_GeneralInformation_originalAlphabetOrScriptOfTitle",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8165,15 +10170,19 @@
               "solr": "008continuing34_GeneralInformation_entryConvention",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8192,51 +10201,65 @@
               "solr": "008map18_GeneralInformation_relief",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Color [OBSOLETE, 1980]"
+                  "code": "h",
+                  "label": "Color [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             },
@@ -8249,147 +10272,195 @@
               "solr": "008map22_GeneralInformation_projection",
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8403,33 +10474,43 @@
               "solr": "008map25_GeneralInformation_typeOfCartographicMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8443,39 +10524,51 @@
               "solr": "008map28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8489,36 +10582,47 @@
               "solr": "008map29_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8532,12 +10636,15 @@
               "solr": "008map31_GeneralInformation_index",
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8552,66 +10659,93 @@
               "solr": "008map33_GeneralInformation_specialFormatCharacteristics",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Photocopy, blue line print [OBSOLETE, 1982]"
+                  "code": "a",
+                  "label": "Photocopy, blue line print [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Photocopy [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Negative photocopy [OBSOLETE, 1982]"
+                  "code": "c",
+                  "label": "Negative photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "d": {
-                  "label": "Film negative [OBSOLETE, 1982]"
+                  "code": "d",
+                  "label": "Film negative [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Facsimile [OBSOLETE, 1982]"
+                  "code": "f",
+                  "label": "Facsimile [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Relief model [OBSOLETE, 1982]"
+                  "code": "g",
+                  "label": "Relief model [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Rare [OBSOLETE, 1982]"
+                  "code": "h",
+                  "label": "Rare [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Braille [OBSOLETE, 1998]"
+                  "code": "m",
+                  "label": "Braille [OBSOLETE, 1998]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Large print [OBSOLETE, 1998]"
+                  "code": "q",
+                  "label": "Large print [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             }
@@ -8628,60 +10762,83 @@
               "solr": "008mixed23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Handwritten transcript [OBSOLETE, 1987]"
+                  "code": "j",
+                  "label": "Handwritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Photocopy [OBSOLETE, 1987]"
+                  "code": "p",
+                  "label": "Photocopy [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Typewritten transcript [OBSOLETE, 1987]"
+                  "code": "t",
+                  "label": "Typewritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             }
@@ -8698,222 +10855,295 @@
               "solr": "008music18_GeneralInformation_formOfComposition",
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8927,54 +11157,71 @@
               "solr": "008music20_GeneralInformation_formatOfMusic",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8988,30 +11235,37 @@
               "solr": "008music21_GeneralInformation_musicParts",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Parts exist"
+                  "code": "a",
+                  "label": "Parts exist",
+                  "deprecated": true
                 }
               }
             },
@@ -9024,42 +11278,54 @@
               "solr": "008music22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -9072,54 +11338,73 @@
               "solr": "008music23_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]"
+                  "code": "x",
+                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -9133,63 +11418,80 @@
               "solr": "008music24_GeneralInformation_accompanyingMatter",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
-                  "label": "Technical and/or historical information on instruments"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Historical information other than music [OBSOLETE, 1980]"
+                  "code": "j",
+                  "label": "Historical information other than music [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]"
+                  "code": "l",
+                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -9203,69 +11505,91 @@
               "solr": "008music30_GeneralInformation_literaryTextForSoundRecordings",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9279,24 +11603,31 @@
               "solr": "008music33_GeneralInformation_transpositionAndArrangement",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9314,18 +11645,23 @@
               "solr": "008visual18_GeneralInformation_runningTime",
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -9339,66 +11675,86 @@
               "solr": "008visual22_GeneralInformation_targetAudience",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
-                  "label": "Specialized"
+                  "code": "f",
+                  "label": "General [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "General"
+                  "code": "g",
+                  "label": "Specialized [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "f": {
-                  "label": "General [OBSOLETE]"
-                },
-                "g": {
-                  "label": "Specialized [OBSOLETE]"
                 },
                 "h": {
-                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]"
+                  "code": "k",
+                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]"
+                  "code": "m",
+                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]"
+                  "code": "p",
+                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]"
+                  "code": "q",
+                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "s": {
-                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]"
+                  "code": "s",
+                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Gifted [OBSOLETE] [CAN/MARC only]"
+                  "code": "t",
+                  "label": "Gifted [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -9411,45 +11767,57 @@
               "solr": "008visual28_GeneralInformation_governmentPublication",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -9462,36 +11830,47 @@
               "solr": "008visual29_GeneralInformation_formOfItem",
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9505,72 +11884,93 @@
               "solr": "008visual33_GeneralInformation_typeOfVisualMaterial",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "e": {
-                  "label": "Electronic videorecording [OBSOLETE, 1975]"
+                  "code": "e",
+                  "label": "Electronic videorecording [OBSOLETE, 1975]",
+                  "deprecated": true
                 }
               }
             },
@@ -9583,30 +11983,37 @@
               "solr": "008visual34_GeneralInformation_technique",
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             }
@@ -9752,9 +12159,11 @@
         "label": "National bibliographic agency",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library and Archives Canada"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -9795,9 +12204,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Copyright or legal deposit number"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -9913,11 +12324,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0208_Isbn_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Binding information (BK, MP, MU) [OBSOLETE]"
+          "label": "Binding information (BK, MP, MU) [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -9931,12 +12341,15 @@
         "label": "Level of international interest",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "0": {
+            "code": "0",
             "label": "Continuing resource of international interest"
           },
           "1": {
+            "code": "1",
             "label": "Continuing resource not of international interest"
           }
         }
@@ -9994,14 +12407,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0228_Issn_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Form of issue [OBSOLETE] [CAN/MARC only]"
+          "label": "Form of issue [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         },
         "c": {
-          "label": "Price [OBSOLETE] [CAN/MARC only]"
+          "label": "Price [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -10015,24 +12428,31 @@
         "label": "Type of standard number or code",
         "codes": {
           "0": {
+            "code": "0",
             "label": "International Standard Recording Code"
           },
           "1": {
+            "code": "1",
             "label": "Universal Product Code"
           },
           "2": {
+            "code": "2",
             "label": "International Standard Music Number"
           },
           "3": {
+            "code": "3",
             "label": "International Article Number"
           },
           "4": {
+            "code": "4",
             "label": "Serial Item and Contribution Identifier"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Unspecified type of standard number or code"
           }
         }
@@ -10041,12 +12461,15 @@
         "label": "Difference indicator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No difference"
           },
           "1": {
+            "code": "1",
             "label": "Difference"
           }
         }
@@ -10093,11 +12516,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0248_OtherStandardIdentifier_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Additional codes following the standard number [OBSOLETE]"
+          "label": "Additional codes following the standard number [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -10228,24 +12650,31 @@
         "label": "Type of number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Issue number"
           },
           "1": {
+            "code": "1",
             "label": "Matrix number"
           },
           "2": {
+            "code": "2",
             "label": "Plate number"
           },
           "3": {
+            "code": "3",
             "label": "Other music publisher number"
           },
           "4": {
+            "code": "4",
             "label": "Video recording publisher number"
           },
           "5": {
+            "code": "5",
             "label": "Other publisher number"
           },
           "6": {
+            "code": "6",
             "label": "Distributor number"
           }
         }
@@ -10254,15 +12683,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "Note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -10483,15 +12916,19 @@
         "label": "Type of date in subfield $a",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No date information"
           },
           "0": {
+            "code": "0",
             "label": "Single date"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates"
           }
         }
@@ -10500,15 +12937,19 @@
         "label": "Type of event",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Capture"
           },
           "1": {
+            "code": "1",
             "label": "Broadcast"
           },
           "2": {
+            "code": "2",
             "label": "Finding"
           }
         }
@@ -10579,18 +13020,21 @@
         "label": "Type of scale",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Scale indeterminable/No scale recorded"
           },
           "1": {
+            "code": "1",
             "label": "Single scale"
           },
           "3": {
+            "code": "3",
             "label": "Range of scales"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -10598,12 +13042,15 @@
         "label": "Type of ring",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Outer ring"
           },
           "1": {
+            "code": "1",
             "label": "Exclusion ring"
           }
         }
@@ -10814,12 +13261,15 @@
         "label": "Source of acquisition sequence",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -10969,12 +13419,15 @@
         "label": "Translation indication",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item not a translation/does not include a translation"
           },
           "1": {
+            "code": "1",
             "label": "Item is or includes a translation"
           }
         }
@@ -10983,9 +13436,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -11112,11 +13567,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0418_Language_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]"
+          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]",
+          "deprecated": true
         }
       }
     },
@@ -11246,15 +13700,19 @@
         "label": "Type of time period in subfield $b or $c",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Subfield $b or $c not present"
           },
           "0": {
+            "code": "0",
             "label": "Single date/time"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates/times"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates/times"
           }
         }
@@ -11299,15 +13757,19 @@
         "label": "Type of entity",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Work"
           },
           "2": {
+            "code": "2",
             "label": "Expression"
           },
           "3": {
+            "code": "3",
             "label": "Manifestation"
           }
         }
@@ -11419,9 +13881,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC musical composition code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -11456,9 +13920,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -11499,12 +13965,15 @@
         "label": "Existence in LC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in LC"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in LC"
           }
         }
@@ -11513,27 +13982,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by LC"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided"
           },
-          "0": {
-            "label": "No series involved"
+          " ": {
+            "code": " ",
+            "label": "No information provided",
+            "deprecated": true
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           }
         }
       },
@@ -11574,11 +14049,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0508_ClassificationLcc_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Supplementary class number (MU) [OBSOLETE, 1981]"
+          "label": "Supplementary class number (MU) [OBSOLETE, 1981]",
+          "deprecated": true
         }
       }
     },
@@ -11623,18 +14097,21 @@
         "label": "Code source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library of Congress Classification"
           },
           "1": {
+            "code": "1",
             "label": "U.S. Dept. of Defense Classification"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]"
+            "code": "0",
+            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]",
+            "deprecated": true
           }
         }
       },
@@ -11682,11 +14159,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "0528_GeographicClassification_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Subject (MP) [OBSOLETE]"
+          "label": "Subject (MP) [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -11700,12 +14176,15 @@
         "label": "Existence in LAC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Information not provided"
           },
           "0": {
+            "code": "0",
             "label": "Work held by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Work not held by LAC"
           }
         }
@@ -11714,33 +14193,43 @@
         "label": "Type, completeness, source of class/call number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "LC-based call number assigned by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Complete LC class number assigned by LAC"
           },
           "2": {
+            "code": "2",
             "label": "Incomplete LC class number assigned by LAC"
           },
           "3": {
+            "code": "3",
             "label": "LC-based call number assigned by the contributing library"
           },
           "4": {
+            "code": "4",
             "label": "Complete LC class number assigned by the contributing library"
           },
           "5": {
+            "code": "5",
             "label": "Incomplete LC class number assigned by the contributing library"
           },
           "6": {
+            "code": "6",
             "label": "Other call number assigned by LAC"
           },
           "7": {
+            "code": "7",
             "label": "Other class number assigned by LAC"
           },
           "8": {
+            "code": "8",
             "label": "Other call number assigned by the contributing library"
           },
           "9": {
+            "code": "9",
             "label": "Other class number assigned by the contributing library"
           }
         }
@@ -11796,12 +14285,15 @@
         "label": "Existence in NLM collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NLM"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NLM"
           }
         }
@@ -11810,27 +14302,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by NLM"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than NLM"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "No series involved"
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           },
           " ": {
-            "label": "No information provided [OBSOLETE]"
+            "code": " ",
+            "label": "No information provided [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -11930,12 +14428,15 @@
         "label": "Existence in NAL collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NAL"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NAL"
           }
         }
@@ -12012,15 +14513,17 @@
         "label": "Code source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "NAL subject category code list"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "undefined"
+            "code": " ",
+            "label": "undefined",
+            "deprecated": true
           }
         }
       },
@@ -12090,12 +14593,15 @@
         "label": "Type of edition",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Full"
           },
           "1": {
+            "code": "1",
             "label": "Abridged"
           }
         }
@@ -12156,21 +14662,26 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]"
+            "code": " ",
+            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           },
           "2": {
-            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -12178,18 +14689,17 @@
         "label": "Source of classification number",
         "codes": {
           " ": {
-            "label": "No information provided"
+            "code": " ",
+            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]",
+            "deprecated": true
           },
           "0": {
+            "code": "0",
             "label": "Assigned by LC"
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]"
           }
         }
       },
@@ -12200,9 +14710,8 @@
           "solr": "082a_ClassificationDdc"
         },
         "b": {
-          "label": "Item number",
-          "repeatable": false,
-          "solr": "082b_ClassificationDdc_itemPortion"
+          "label": "DDC number-abridged NST version (SE) [OBSOLETE]",
+          "deprecated": true
         },
         "m": {
           "label": "Standard or optional designation",
@@ -12236,11 +14745,6 @@
           "repeatable": true,
           "solr": "0828_ClassificationDdc_fieldLink"
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "DDC number-abridged NST version (SE) [OBSOLETE]"
-        }
       }
     },
     "083": {
@@ -12253,12 +14757,15 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
           }
         }
@@ -12482,24 +14989,23 @@
         "label": "Number source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Source specified in subfield $2"
           },
           "0": {
-            "label": "Superintendent of Documents Classification System"
+            "code": "0",
+            "label": "United States",
+            "deprecated": true
           },
           "1": {
-            "label": "Government of Canada Publications: Outline of Classification"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "United States"
-          },
-          "1": {
-            "label": "Canada"
+            "code": "1",
+            "label": "Canada",
+            "deprecated": true
           },
           "2-9": {
-            "label": "Reserved"
+            "code": "2-9",
+            "label": "Reserved",
+            "deprecated": true
           }
         }
       },
@@ -12587,12 +15093,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -12725,12 +15234,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -12853,12 +15365,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -12986,6 +15501,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -13107,9 +15623,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -13118,9 +15636,11 @@
         "label": "Type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Abbreviated key title"
           },
           "0": {
+            "code": "0",
             "label": "Other abbreviated title"
           }
         }
@@ -13171,24 +15691,28 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
-            "label": "No nonfiling characters"
+            "code": "0",
+            "label": "Key title is same as field 245 / No key title added entry; title proper same",
+            "deprecated": true
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "Key title is same as field 245 / No key title added entry; title proper same"
           },
           "1": {
-            "label": "Key title is not the same as field 245 / Key title added entry; title proper different"
+            "code": "1",
+            "label": "Key title is not the same as field 245 / Key title added entry; title proper different",
+            "deprecated": true
           },
           "2": {
-            "label": "Key title added entry; title proper same"
+            "code": "2",
+            "label": "Key title added entry; title proper same",
+            "deprecated": true
           },
           "3": {
-            "label": "No key title added entry; title proper different"
+            "code": "3",
+            "label": "No key title added entry; title proper different",
+            "deprecated": true
           }
         }
       },
@@ -13226,18 +15750,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -13245,6 +15773,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -13360,9 +15889,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -13371,9 +15902,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -13425,14 +15958,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2428_TitleTranslation_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
+          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
+          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -13446,18 +15979,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -13465,6 +16002,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -13558,9 +16096,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -13569,9 +16109,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -13642,14 +16184,14 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2458_Title_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -13663,15 +16205,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "No note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -13680,33 +16226,43 @@
         "label": "Type of title",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Portion of title"
           },
           "1": {
+            "code": "1",
             "label": "Parallel title"
           },
           "2": {
+            "code": "2",
             "label": "Distinctive title"
           },
           "3": {
+            "code": "3",
             "label": "Other title"
           },
           "4": {
+            "code": "4",
             "label": "Cover title"
           },
           "5": {
+            "code": "5",
             "label": "Added title page title"
           },
           "6": {
+            "code": "6",
             "label": "Caption title"
           },
           "7": {
+            "code": "7",
             "label": "Running title"
           },
           "8": {
+            "code": "8",
             "label": "Spine title"
           }
         }
@@ -13773,17 +16329,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2468_ParallelTitle_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]"
+          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]",
+          "deprecated": true
         },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -13797,9 +16354,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -13808,9 +16367,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -13871,17 +16432,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2478_VariantTitle_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "c": {
-          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]"
+          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -14182,21 +16744,26 @@
         "label": "Sequence of publishing statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest available publisher"
           },
           "2": {
+            "code": "2",
             "label": "Intervening publisher"
           },
           "3": {
+            "code": "3",
             "label": "Current/latest publisher"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Publisher, distributor, etc. is present"
+            "code": "0",
+            "label": "Publisher, distributor, etc. is present",
+            "deprecated": true
           },
           "1": {
-            "label": "Publisher, distributor, etc. not present"
+            "code": "1",
+            "label": "Publisher, distributor, etc. not present",
+            "deprecated": true
           }
         }
       },
@@ -14247,17 +16814,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "2608_Publication_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]"
+          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]",
+          "deprecated": true
         },
         "k": {
-          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         },
         "l": {
-          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -14298,12 +16866,15 @@
         "label": "Sequence of statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -14312,18 +16883,23 @@
         "label": "Function of entity",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Production"
           },
           "1": {
+            "code": "1",
             "label": "Publication"
           },
           "2": {
+            "code": "2",
             "label": "Distribution"
           },
           "3": {
+            "code": "3",
             "label": "Manufacture"
           },
           "4": {
+            "code": "4",
             "label": "Copyright notice date"
           }
         }
@@ -14377,12 +16953,15 @@
         "label": "Level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -14391,12 +16970,15 @@
         "label": "Type of address",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Mailing"
           },
           "7": {
+            "code": "7",
             "label": "Type specified in subfield $i"
           }
         }
@@ -14570,17 +17152,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "3008_PhysicalDescription_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]"
+          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "m": {
-          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         },
         "n": {
-          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -14621,9 +17204,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Hours"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -15164,12 +17749,15 @@
         "label": "Application",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Adaptive features to access primary content"
           },
           "1": {
+            "code": "1",
             "label": "Adaptive features to access secondary content"
           }
         }
@@ -15234,9 +17822,11 @@
         "label": "Geospatial reference dimension",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Horizontal coordinate system"
           },
           "1": {
+            "code": "1",
             "label": "Vertical coordinate system"
           }
         }
@@ -15245,30 +17835,39 @@
         "label": "Geospatial reference method",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Geographic"
           },
           "1": {
+            "code": "1",
             "label": "Map projection"
           },
           "2": {
+            "code": "2",
             "label": "Grid coordinate system"
           },
           "3": {
+            "code": "3",
             "label": "Local planar"
           },
           "4": {
+            "code": "4",
             "label": "Local"
           },
           "5": {
+            "code": "5",
             "label": "Geodetic model"
           },
           "6": {
+            "code": "6",
             "label": "Altitude"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in $2"
           },
           "8": {
+            "code": "8",
             "label": "Depth"
           }
         }
@@ -15997,24 +18596,31 @@
         "label": "Controlled element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Document"
           },
           "1": {
+            "code": "1",
             "label": "Title"
           },
           "2": {
+            "code": "2",
             "label": "Abstract"
           },
           "3": {
+            "code": "3",
             "label": "Contents note"
           },
           "4": {
+            "code": "4",
             "label": "Author"
           },
           "5": {
+            "code": "5",
             "label": "Record"
           },
           "8": {
+            "code": "8",
             "label": "None of the above"
           }
         }
@@ -16133,12 +18739,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -16244,9 +18853,11 @@
         "label": "Format of date",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Formatted style"
           },
           "1": {
+            "code": "1",
             "label": "Unformatted note"
           }
         }
@@ -16286,12 +18897,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -16300,12 +18914,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -16419,12 +19036,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -16433,12 +19053,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -16708,9 +19331,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in $2"
           }
         }
@@ -16894,18 +19519,23 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Medium of performance"
           },
           "1": {
+            "code": "1",
             "label": "Partial medium of performance"
           },
           "2": {
+            "code": "2",
             "label": "Medium of performance of musical content of representative expression"
           },
           "3": {
+            "code": "3",
             "label": "Partial medium of performance of musical content of representative expression"
           }
         }
@@ -16914,12 +19544,15 @@
         "label": "Access control",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not intended for access"
           },
           "1": {
+            "code": "1",
             "label": "Intended for access"
           }
         }
@@ -17088,15 +19721,19 @@
         "label": "Key type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Relationship to original unknown"
           },
           "0": {
+            "code": "0",
             "label": "Original key"
           },
           "1": {
+            "code": "1",
             "label": "Transposed key"
           },
           "2": {
+            "code": "2",
             "label": "Key of representative expression"
           }
         }
@@ -17414,12 +20051,15 @@
         "label": "Type of time period",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Creation of work"
           },
           "2": {
+            "code": "2",
             "label": "Creation of aggregate work"
           }
         }
@@ -17480,12 +20120,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -17494,9 +20137,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -17606,12 +20251,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -17620,9 +20268,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -17732,12 +20382,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -17746,9 +20399,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "9": {
+            "code": "9",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -17859,9 +20514,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -17913,11 +20570,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "4408_SeriesStatementAddedEntryTitle_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "h": {
-          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]"
+          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -17931,9 +20587,11 @@
         "label": "Series tracing policy",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Series not traced"
           },
           "1": {
+            "code": "1",
             "label": "Series traced"
           }
         }
@@ -18032,17 +20690,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5008_GeneralNote_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "l": {
-          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]"
+          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "x": {
-          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]"
+          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "z": {
-          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18182,15 +20841,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Contents"
           },
           "1": {
+            "code": "1",
             "label": "Incomplete contents"
           },
           "2": {
+            "code": "2",
             "label": "Partial contents"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18199,9 +20862,11 @@
         "label": "Level of content designation",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Enhanced"
           }
         }
@@ -18260,12 +20925,15 @@
         "label": "Restriction",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No restrictions"
           },
           "1": {
+            "code": "1",
             "label": "Restrictions apply"
           }
         }
@@ -18420,18 +21088,23 @@
         "label": "Coverage/location in source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Coverage unknown"
           },
           "1": {
+            "code": "1",
             "label": "Coverage complete"
           },
           "2": {
+            "code": "2",
             "label": "Coverage is selective"
           },
           "3": {
+            "code": "3",
             "label": "Location in source not given"
           },
           "4": {
+            "code": "4",
             "label": "Location in source given"
           }
         }
@@ -18496,18 +21169,22 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No display constant generated"
           },
           "1": {
+            "code": "1",
             "label": "Cast"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Presenter (VM, MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Presenter (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Narrator (VM, MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Narrator (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -18684,11 +21361,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5158_NumberingPeculiarities_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18702,9 +21378,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Type of file"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18808,24 +21486,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Summary"
           },
           "0": {
+            "code": "0",
             "label": "Subject"
           },
           "1": {
+            "code": "1",
             "label": "Review"
           },
           "2": {
+            "code": "2",
             "label": "Scope and content"
           },
           "3": {
+            "code": "3",
             "label": "Abstract"
           },
           "4": {
+            "code": "4",
             "label": "Content advice"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18878,11 +21563,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5208_Summary_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18896,24 +21580,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Audience"
           },
           "0": {
+            "code": "0",
             "label": "Reading grade level"
           },
           "1": {
+            "code": "1",
             "label": "Interest age level"
           },
           "2": {
+            "code": "2",
             "label": "Interest grade level"
           },
           "3": {
+            "code": "3",
             "label": "Special audience characteristics"
           },
           "4": {
+            "code": "4",
             "label": "Motivation/interest level"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18958,9 +21649,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Geographic coverage"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18995,9 +21688,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Cite as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -19057,11 +21752,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5258_SupplementaryContent_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -19075,9 +21769,11 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Reading program"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -19187,11 +21883,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5308_AdditionalPhysicalFormAvailable_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -19205,15 +21900,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Accessibility technical details"
           },
           "1": {
+            "code": "1",
             "label": "Accessibility features"
           },
           "2": {
+            "code": "2",
             "label": "Accessibility deficiencies"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -19235,11 +21934,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5328_AccessibilityNote_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -19561,18 +22259,22 @@
         "label": "Custodial role",
         "codes": {
           "1": {
+            "code": "1",
             "label": "Holder of originals"
           },
           "2": {
+            "code": "2",
             "label": "Holder of duplicates"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Repository (AM) [OBSOLETE, 1984]"
+            "code": "0",
+            "label": "Repository (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           },
           "3": {
-            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]"
+            "code": "3",
+            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           }
         }
       },
@@ -19819,12 +22521,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -19909,12 +22614,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -20049,12 +22757,15 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Associated materials"
           },
           "1": {
+            "code": "1",
             "label": "Related materials"
           }
         }
@@ -20119,12 +22830,15 @@
         "label": "Type of data",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Biographical sketch"
           },
           "1": {
+            "code": "1",
             "label": "Administrative history"
           }
         }
@@ -20198,11 +22912,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5468_Language_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -20230,11 +22943,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5478_FormerTitleComplexity_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -20267,11 +22979,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5508_IssuingBody_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -20397,12 +23108,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Indexes"
           },
           "0": {
+            "code": "0",
             "label": "Finding aids"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -20467,9 +23181,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Documentation"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -20509,12 +23225,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -20551,11 +23270,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5618_CustodialHistory_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Time of collation (NR) [OBSOLETE, 1997]"
+          "label": "Time of collation (NR) [OBSOLETE, 1997]",
+          "deprecated": true
         }
       }
     },
@@ -20668,12 +23386,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "File size"
           },
           "0": {
+            "code": "0",
             "label": "Case file characteristics"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -20733,9 +23454,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Methodology"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -20805,11 +23528,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "5808_LinkingEntryComplexity_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information [OBSOLETE, 1990]"
+          "label": "Source of note information [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -20823,9 +23545,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Publications"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -20870,12 +23594,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -21085,9 +23812,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Awards"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -21127,12 +23856,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Source of description"
           },
           "1": {
+            "code": "1",
             "label": "Latest issue consulted"
           }
         }
@@ -21172,18 +23904,21 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Multiple surname [OBSOLETE, 1996]"
+            "code": "2",
+            "label": "Multiple surname [OBSOLETE, 1996]",
+            "deprecated": true
           }
         }
       },
@@ -21191,27 +23926,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -21393,12 +24136,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -21407,27 +24153,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -21599,12 +24353,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -21613,27 +24370,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -21795,6 +24560,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -21803,27 +24569,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -21981,27 +24755,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22092,27 +24874,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22193,15 +24983,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -22210,27 +25004,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22242,9 +25044,8 @@
           "solr": "650a_Topic_topicalTerm"
         },
         "b": {
-          "label": "Topical term following geographic name entry element",
-          "repeatable": false,
-          "solr": "650b_Topic_topicalTerm"
+          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]",
+          "deprecated": true
         },
         "c": {
           "label": "Location of event",
@@ -22330,11 +25131,6 @@
           "repeatable": true,
           "solr": "6508_Topic_fieldLink"
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]"
-        }
       }
     },
     "651": {
@@ -22348,27 +25144,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22452,11 +25256,10 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "6518_Geographic_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Geographic name following place entry element [OBSOLETE, 1981]"
+          "label": "Geographic name following place entry element [OBSOLETE, 1981]",
+          "deprecated": true
         }
       }
     },
@@ -22470,15 +25273,19 @@
         "label": "Level of index term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -22487,27 +25294,35 @@
         "label": "Type of term or name",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Topical term"
           },
           "1": {
+            "code": "1",
             "label": "Personal name"
           },
           "2": {
+            "code": "2",
             "label": "Corporate name"
           },
           "3": {
+            "code": "3",
             "label": "Meeting name"
           },
           "4": {
+            "code": "4",
             "label": "Chronological term"
           },
           "5": {
+            "code": "5",
             "label": "Geographic name"
           },
           "6": {
+            "code": "6",
             "label": "Genre/form term"
           }
         }
@@ -22562,15 +25377,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -22663,9 +25482,11 @@
         "label": "Type of heading",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Faceted"
           }
         }
@@ -22674,27 +25495,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22791,6 +25620,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -22872,6 +25702,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -23092,9 +25923,11 @@
         "label": "Source of name, title, or term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -23166,12 +25999,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -23180,9 +26016,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -23359,12 +26197,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -23373,9 +26214,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -23542,12 +26385,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -23556,9 +26402,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -23715,12 +26563,15 @@
         "label": "Type of name",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "1": {
+            "code": "1",
             "label": "Personal"
           },
           "2": {
+            "code": "2",
             "label": "Other"
           }
         }
@@ -23787,6 +26638,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -23795,9 +26647,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -23939,15 +26793,17 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "Nonfiling characters not specified [OBSOLETE, 1980]"
+            "code": " ",
+            "label": "Nonfiling characters not specified [OBSOLETE, 1980]",
+            "deprecated": true
           }
         }
       },
@@ -23955,21 +26811,27 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]"
+            "code": "0",
+            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "1": {
-            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]"
+            "code": "1",
+            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Not printed on card [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Not printed on card [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -24360,9 +27222,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24371,9 +27235,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Main series"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24620,9 +27486,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24631,9 +27499,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has subseries"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24880,9 +27750,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24891,9 +27763,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translation of"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25160,9 +28034,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25171,9 +28047,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translated as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25440,9 +28318,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25451,9 +28331,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has supplement"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25720,9 +28602,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25731,18 +28615,21 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Supplement to"
           },
           "0": {
+            "code": "0",
             "label": "Parent"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "1": {
-            "label": "Special issue [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "Special issue [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -26008,9 +28895,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -26019,9 +28908,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "In"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -26299,9 +29190,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -26310,15 +29203,17 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Constituent unit"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Includes [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Includes [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -26584,9 +29479,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -26595,21 +29492,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Other edition available"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Entry not the same"
+            "code": "0",
+            "label": "Entry not the same",
+            "deprecated": true
           },
           "1": {
-            "label": "Entry is the same as title"
+            "code": "1",
+            "label": "Entry is the same as title",
+            "deprecated": true
           },
           "2": {
-            "label": "Entry is the same as main entry and title"
+            "code": "2",
+            "label": "Entry is the same as main entry and title",
+            "deprecated": true
           }
         }
       },
@@ -26885,9 +29788,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -26896,9 +29801,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Available in another form"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -27165,9 +30072,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -27176,21 +30085,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Issued with"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Issued with [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Issued with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "1": {
-            "label": "With [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "With [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "2": {
-            "label": "Bound with [OBSOLETE] [CAN/MARC only]"
+            "code": "2",
+            "label": "Bound with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -27456,9 +30371,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -27467,27 +30384,35 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continues"
           },
           "1": {
+            "code": "1",
             "label": "Continues in part"
           },
           "2": {
+            "code": "2",
             "label": "Supersedes"
           },
           "3": {
+            "code": "3",
             "label": "Supersedes in part"
           },
           "4": {
+            "code": "4",
             "label": "Formed by the union of ... and ..."
           },
           "5": {
+            "code": "5",
             "label": "Absorbed"
           },
           "6": {
+            "code": "6",
             "label": "Absorbed in part"
           },
           "7": {
+            "code": "7",
             "label": "Separated from"
           }
         }
@@ -27755,9 +30680,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -27766,30 +30693,39 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continued by"
           },
           "1": {
+            "code": "1",
             "label": "Continued in part by"
           },
           "2": {
+            "code": "2",
             "label": "Superseded by"
           },
           "3": {
+            "code": "3",
             "label": "Superseded in part by"
           },
           "4": {
+            "code": "4",
             "label": "Absorbed by"
           },
           "5": {
+            "code": "5",
             "label": "Absorbed in part by"
           },
           "6": {
+            "code": "6",
             "label": "Split into ... and ..."
           },
           "7": {
+            "code": "7",
             "label": "Merged with ... to form ..."
           },
           "8": {
+            "code": "8",
             "label": "Changed back to"
           }
         }
@@ -28056,9 +30992,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -28067,9 +31005,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Data source"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -28351,9 +31291,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -28362,9 +31304,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Related item"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -28631,9 +31575,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -28642,9 +31588,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Parallel description in another language of cataloging"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -28739,12 +31687,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -29013,12 +31964,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -29277,12 +32231,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -29532,9 +32489,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -29840,17 +32799,18 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "8508_HeldBy_fieldLink"
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "d": {
-          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "e": {
-          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -29864,33 +32824,43 @@
         "label": "Shelving scheme",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Library of Congress classification"
           },
           "1": {
+            "code": "1",
             "label": "Dewey Decimal classification"
           },
           "2": {
+            "code": "2",
             "label": "National Library of Medicine classification"
           },
           "3": {
+            "code": "3",
             "label": "Superintendent of Documents classification"
           },
           "4": {
+            "code": "4",
             "label": "Shelving control number"
           },
           "5": {
+            "code": "5",
             "label": "Title"
           },
           "6": {
+            "code": "6",
             "label": "Shelved separately"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Other scheme"
           }
         }
@@ -29899,15 +32869,19 @@
         "label": "Shelving order",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not enumeration"
           },
           "1": {
+            "code": "1",
             "label": "Primary enumeration"
           },
           "2": {
+            "code": "2",
             "label": "Alternative enumeration"
           }
         }
@@ -30054,24 +33028,31 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Email"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "2": {
+            "code": "2",
             "label": "Remote login (Telnet)"
           },
           "3": {
+            "code": "3",
             "label": "Dial-up"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -30080,24 +33061,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -30129,19 +33117,16 @@
           "solr": "856f_ElectronicLocationAndAccess_name"
         },
         "g": {
-          "label": "Persistent identifier",
-          "repeatable": true,
-          "solr": "856g_ElectronicLocationAndAccess_pid"
+          "label": "Uniform Resource Name [OBSOLETE, 2000]",
+          "deprecated": true
         },
         "h": {
-          "label": "Non-functioning Uniform Resource Identifier",
-          "repeatable": true,
-          "solr": "856h_ElectronicLocationAndAccess_nonFunctioningURI"
+          "label": "Processor of request [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "l": {
-          "label": "Standardized information governing access",
-          "repeatable": true,
-          "solr": "856l_ElectronicLocationAndAccess_access"
+          "label": "Logon [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "m": {
           "label": "Contact for access assistance",
@@ -30149,9 +33134,8 @@
           "solr": "856m_ElectronicLocationAndAccess_contact"
         },
         "n": {
-          "label": "Terms governing access",
-          "repeatable": true,
-          "solr": "856n_ElectronicLocationAndAccess_terms"
+          "label": "Name of location of host [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "o": {
           "label": "Operating system",
@@ -30169,9 +33153,8 @@
           "solr": "856q_ElectronicLocationAndAccess_format"
         },
         "r": {
-          "label": "Standardized information governing use and reproduction",
-          "repeatable": true,
-          "solr": "856r_ElectronicLocationAndAccess_use"
+          "label": "Settings [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "s": {
           "label": "File size",
@@ -30179,9 +33162,8 @@
           "solr": "856s_ElectronicLocationAndAccess_fileSize"
         },
         "t": {
-          "label": "Terms governing use and reproduction",
-          "repeatable": true,
-          "solr": "856t_ElectronicLocationAndAccess_termsOfUse"
+          "label": "Terminal emulation [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "u": {
           "label": "Uniform Resource Identifier",
@@ -30240,38 +33222,22 @@
           "label": "Field link and sequence number",
           "repeatable": true,
           "solr": "8568_ElectronicLocationAndAccess_fieldLink"
-        }
-      },
-      "historical-subfields": {
-        "g": {
-          "label": "Uniform Resource Name [OBSOLETE, 2000]"
         },
         "b": {
-          "label": "Access number [OBSOLETE, 2020]"
-        },
-        "h": {
-          "label": "Processor of request [OBSOLETE, 2020]"
+          "label": "Access number [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "i": {
-          "label": "Instruction [OBSOLETE, 2020]"
+          "label": "Instruction [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "j": {
-          "label": "Bits per second [OBSOLETE, 2020]"
+          "label": "Bits per second [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "k": {
-          "label": "Password [OBSOLETE, 2020]"
-        },
-        "l": {
-          "label": "Logon [OBSOLETE, 2020]"
-        },
-        "n": {
-          "label": "Name of location of host [OBSOLETE, 2020]"
-        },
-        "r": {
-          "label": "Settings [OBSOLETE, 2020]"
-        },
-        "t": {
-          "label": "Terminal emulation [OBSOLETE, 2020]"
+          "label": "Password [OBSOLETE, 2020]",
+          "deprecated": true
         }
       }
     },
@@ -30285,15 +33251,19 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -30302,24 +33272,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -30459,15 +33436,19 @@
         "label": "Field encoding level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "3": {
+            "code": "3",
             "label": "Holdings level 3"
           },
           "4": {
+            "code": "4",
             "label": "Holdings level 4"
           },
           "5": {
+            "code": "5",
             "label": "Holdings level 4 with piece designation"
           }
         }
@@ -30476,15 +33457,19 @@
         "label": "Type of notation",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Non-standard"
           },
           "1": {
+            "code": "1",
             "label": "ANSI/NISO Z39.71 or ISO 10324"
           },
           "2": {
+            "code": "2",
             "label": "ANSI Z39.42"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -30860,15 +33845,19 @@
         "label": "Method of assignment",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided/not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Fully machine-generated"
           },
           "1": {
+            "code": "1",
             "label": "Partially machine-generated"
           },
           "2": {
+            "code": "2",
             "label": "Not machine-generated"
           }
         }
@@ -31044,12 +34033,15 @@
         "label": "Type of field",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Leader"
           },
           "1": {
+            "code": "1",
             "label": "Variable control fields (002-009)"
           },
           "2": {
+            "code": "2",
             "label": "Variable data fields (010-999)"
           }
         }
@@ -31072,14 +34064,12 @@
           "solr": "8862_ForeignMARCInformationField"
         },
         "c": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true,
-          "solr": "886c_ForeignMARCInformationField"
+          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "d": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true,
-          "solr": "886d_ForeignMARCInformationField"
+          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "e": {
           "label": "Foreign MARC subfield",
@@ -31235,14 +34225,6 @@
           "label": "Foreign MARC subfield",
           "repeatable": true,
           "solr": "8869_ForeignMARCInformationField"
-        }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]"
-        },
-        "d": {
-          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]"
         }
       }
     },

--- a/marc-schema/marc-schema.json
+++ b/marc-schema/marc-schema.json
@@ -22,18 +22,23 @@
           "repeatableContent": false,
           "codes": {
             "a": {
+              "code": "a",
               "label": "Increase in encoding level"
             },
             "c": {
+              "code": "c",
               "label": "Corrected or revised"
             },
             "d": {
+              "code": "d",
               "label": "Deleted"
             },
             "n": {
+              "code": "n",
               "label": "New"
             },
             "p": {
+              "code": "p",
               "label": "Increase in encoding level from prepublication"
             }
           }
@@ -46,57 +51,75 @@
           "repeatableContent": false,
           "codes": {
             "a": {
+              "code": "a",
               "label": "Language material"
             },
             "c": {
+              "code": "c",
               "label": "Notated music"
             },
             "d": {
+              "code": "d",
               "label": "Manuscript notated music"
             },
             "e": {
+              "code": "e",
               "label": "Cartographic material"
             },
             "f": {
+              "code": "f",
               "label": "Manuscript cartographic material"
             },
             "g": {
+              "code": "g",
               "label": "Projected medium"
             },
             "i": {
+              "code": "i",
               "label": "Nonmusical sound recording"
             },
             "j": {
+              "code": "j",
               "label": "Musical sound recording"
             },
             "k": {
+              "code": "k",
               "label": "Two-dimensional nonprojectable graphic"
             },
             "m": {
+              "code": "m",
               "label": "Computer file"
             },
             "o": {
+              "code": "o",
               "label": "Kit"
             },
             "p": {
+              "code": "p",
               "label": "Mixed materials"
             },
             "r": {
+              "code": "r",
               "label": "Three-dimensional artifact or naturally occurring object"
             },
             "t": {
+              "code": "t",
               "label": "Manuscript language material"
-            }
-          },
-          "historical-codes": {
+            },
             "b": {
-              "label": "Archival and manuscripts control [OBSOLETE, 1995]"
+              "code": "b",
+              "label": "Archival and manuscripts control [OBSOLETE, 1995]",
+              "deprecated": true
             },
             "h": {
-              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]"
+              "code": "h",
+              "label": "Microform publications [OBSOLETE, 1972] [USMARC only]",
+              "deprecated": true
             },
             "n": {
-              "label": "Special instructional material"
+              "code": "n",
+              "label": "Special instructional material",
+              "deprecated": true
             }
           }
         },
@@ -108,30 +131,37 @@
           "repeatableContent": false,
           "codes": {
             "a": {
+              "code": "a",
               "label": "Monographic component part"
             },
             "b": {
+              "code": "b",
               "label": "Serial component part"
             },
             "c": {
+              "code": "c",
               "label": "Collection"
             },
             "d": {
+              "code": "d",
               "label": "Subunit"
             },
             "i": {
+              "code": "i",
               "label": "Integrating resource"
             },
             "m": {
+              "code": "m",
               "label": "Monograph/Item"
             },
             "s": {
+              "code": "s",
               "label": "Serial"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]"
+              "code": "p",
+              "label": "Pamphlet [OBSOLETE, 1988] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -143,9 +173,11 @@
           "repeatableContent": false,
           "codes": {
             " ": {
+              "code": " ",
               "label": "No specified type"
             },
             "a": {
+              "code": "a",
               "label": "Archival"
             }
           }
@@ -158,9 +190,11 @@
           "repeatableContent": false,
           "codes": {
             " ": {
+              "code": " ",
               "label": "MARC-8"
             },
             "a": {
+              "code": "a",
               "label": "UCS/Unicode"
             }
           }
@@ -173,6 +207,7 @@
           "repeatableContent": false,
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for indicators"
             }
           }
@@ -185,6 +220,7 @@
           "repeatableContent": false,
           "codes": {
             "2": {
+              "code": "2",
               "label": "Number of character positions used for a subfield code"
             }
           }
@@ -204,42 +240,54 @@
           "repeatableContent": false,
           "codes": {
             " ": {
+              "code": " ",
               "label": "Full level"
             },
             "1": {
+              "code": "1",
               "label": "Full level, material not examined"
             },
             "2": {
+              "code": "2",
               "label": "Less-than-full level, material not examined"
             },
             "3": {
+              "code": "3",
               "label": "Abbreviated level"
             },
             "4": {
+              "code": "4",
               "label": "Core level"
             },
             "5": {
+              "code": "5",
               "label": "Partial (preliminary) level"
             },
             "7": {
+              "code": "7",
               "label": "Minimal level"
             },
             "8": {
+              "code": "8",
               "label": "Prepublication level"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
             },
             "z": {
+              "code": "z",
               "label": "Not applicable"
-            }
-          },
-          "historical-codes": {
+            },
             "0": {
-              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "0",
+              "label": "Full level with item [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             },
             "6": {
-              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]"
+              "code": "6",
+              "label": "Minimal level [OBSOLETE, 1997] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -251,30 +299,38 @@
           "repeatableContent": false,
           "codes": {
             " ": {
+              "code": " ",
               "label": "Non-ISBD"
             },
             "a": {
+              "code": "a",
               "label": "AACR 2"
             },
             "c": {
+              "code": "c",
               "label": "ISBD punctuation omitted"
             },
             "i": {
+              "code": "i",
               "label": "ISBD punctuation included"
             },
             "n": {
+              "code": "n",
               "label": "Non-ISBD punctuation omitted"
             },
             "u": {
+              "code": "u",
               "label": "Unknown"
-            }
-          },
-          "historical-codes": {
+            },
             "p": {
-              "label": "Record is in partial ISBD form [OBSOLETE, 1987]"
+              "code": "p",
+              "label": "Record is in partial ISBD form [OBSOLETE, 1987]",
+              "deprecated": true
             },
             "r": {
-              "label": "Record is in provisional form [OBSOLETE, 1981]"
+              "code": "r",
+              "label": "Record is in provisional form [OBSOLETE, 1981]",
+              "deprecated": true
             }
           }
         },
@@ -286,24 +342,30 @@
           "repeatableContent": false,
           "codes": {
             " ": {
+              "code": " ",
               "label": "Not specified or not applicable"
             },
             "a": {
+              "code": "a",
               "label": "Set"
             },
             "b": {
+              "code": "b",
               "label": "Part with independent title"
             },
             "c": {
+              "code": "c",
               "label": "Part with dependent title"
-            }
-          },
-          "historical-codes": {
+            },
             "r": {
-              "label": "Linked record requirement [OBSOLETE, 2007]"
+              "code": "r",
+              "label": "Linked record requirement [OBSOLETE, 2007]",
+              "deprecated": true
             },
             "2": {
-              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]"
+              "code": "2",
+              "label": "Open entry for a collection [OBSOLETE, 1984] [CAN/MARC only]",
+              "deprecated": true
             }
           }
         },
@@ -315,6 +377,7 @@
           "repeatableContent": false,
           "codes": {
             "4": {
+              "code": "4",
               "label": "Number of characters in the length-of-field portion of a Directory entry"
             }
           }
@@ -327,6 +390,7 @@
           "repeatableContent": false,
           "codes": {
             "5": {
+              "code": "5",
               "label": "Number of characters in the starting-character-position portion of a Directory entry"
             }
           }
@@ -339,6 +403,7 @@
           "repeatableContent": false,
           "codes": {
             "0": {
+              "code": "0",
               "label": "Number of characters in the implementation-defined portion of a Directory entry"
             }
           }
@@ -351,6 +416,7 @@
           "repeatableContent": false,
           "codes": {
             "0": {
+              "code": "0",
               "label": "Undefined"
             }
           }
@@ -387,48 +453,63 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Language material"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Notated music"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Manuscript notated music"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cartographic material"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Manuscript cartographic material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected medium"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nonmusical sound recording"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Musical sound recording"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Two-dimensional nonprojectable graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Computer file"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Mixed materials"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Three-dimensional artifact or naturally occurring object"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Serial/Integrating resource"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Manuscript language material"
                 }
               }
@@ -446,54 +527,71 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -506,33 +604,43 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -545,36 +653,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -588,90 +707,119 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -684,39 +832,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -729,12 +889,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -747,12 +910,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -765,12 +931,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -783,42 +952,55 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -831,21 +1013,27 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -862,33 +1050,43 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -901,15 +1099,19 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -922,45 +1124,59 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -973,39 +1189,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1022,63 +1250,83 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1091,18 +1339,23 @@
               "repeatableContent": false,
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1115,27 +1368,35 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1148,36 +1409,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1190,36 +1462,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1232,87 +1515,115 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1326,87 +1637,115 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1419,39 +1758,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1464,12 +1815,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1482,51 +1836,67 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1539,15 +1909,19 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1565,45 +1939,59 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1616,147 +2004,195 @@
               "repeatableContent": false,
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -1769,33 +2205,43 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1808,39 +2254,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1853,36 +2311,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1895,12 +2364,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1914,36 +2386,47 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -1960,36 +2443,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2006,222 +2500,295 @@
               "repeatableContent": false,
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -2234,54 +2801,71 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2294,24 +2878,31 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2324,33 +2915,43 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2363,36 +2964,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2406,48 +3018,63 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Technical and/or historical information on instruments"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2461,69 +3088,91 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2536,24 +3185,31 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2570,18 +3226,23 @@
               "repeatableContent": false,
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -2594,33 +3255,43 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2633,39 +3304,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2678,36 +3361,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2720,66 +3414,87 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2792,24 +3507,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2833,48 +3555,63 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Map"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tactile material"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Projected graphic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microform"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Nonprojected graphic"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Kit"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Notated music"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound recording"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Text"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Unspecified"
                 }
               }
@@ -2891,51 +3628,67 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Tape cartridge"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Chip cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Computer optical disc cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer disc, type unspecified"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Computer disc cartridge, type unspecified"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Tape cassette"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Tape reel"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magnetic disk"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Computer card"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Magneto-optical disc"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Optical disc"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Standalone device"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -2948,36 +3701,45 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Gray scale"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Hand coloured [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -2989,36 +3751,47 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 1/2 in."
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in."
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm."
                 },
                 "i": {
+                  "code": "i",
                   "label": "1 1/8 x 2 3/8 in."
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8 in."
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3031,15 +3804,19 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3052,18 +3829,23 @@
               "repeatableContent": false,
               "codes": {
                 "001-999": {
+                  "code": "001-999",
                   "label": "Exact bit depth"
                 },
                 "mmm": {
+                  "code": "mmm",
                   "label": "Multiple"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -3076,15 +3858,19 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One file format"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple file formats"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3097,18 +3883,23 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Absent"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Present"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3121,27 +3912,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "File reproduced from original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "File reproduced from microform"
                 },
                 "c": {
+                  "code": "c",
                   "label": "File reproduced from an electronic resource"
                 },
                 "d": {
+                  "code": "d",
                   "label": "File reproduced from an intermediate (not microform)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3154,21 +3953,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncompressed"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Lossless"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Lossy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3181,21 +3986,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Access"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Preservation"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Replacement"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3212,30 +4023,37 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Celestial globe"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Planetary or lunar globe"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Terrestrial globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Earth moon globe"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "d": {
-                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "d",
+                  "label": "Satellite globe (of our solar system), excluding the earth moon [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -3247,18 +4065,21 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3270,51 +4091,67 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3327,18 +4164,23 @@
               "repeatableContent": false,
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3355,9 +4197,11 @@
               "repeatableContent": false,
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3374,87 +4218,124 @@
               "repeatableContent": false,
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Atlas"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Diagram"
                 },
                 "j": {
-                  "label": "Map"
+                  "code": "j",
+                  "label": "Orthophoto",
+                  "deprecated": true
                 },
                 "k": {
+                  "code": "k",
                   "label": "Profile"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Remote-sensing image"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Section"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "y": {
+                  "code": "y",
                   "label": "View"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Aerial chart"
+                  "code": "a",
+                  "label": "Aerial chart",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Aerial remote-sensing image"
+                  "code": "b",
+                  "label": "Aerial remote-sensing image",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Anamorphic map"
+                  "code": "c",
+                  "label": "Anamorphic map",
+                  "deprecated": true
                 },
                 "e": {
-                  "label": "Celestial chart"
+                  "code": "e",
+                  "label": "Celestial chart",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Chart"
+                  "code": "f",
+                  "label": "Chart",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Hydrographic chart"
+                  "code": "h",
+                  "label": "Hydrographic chart",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Imaginative map"
-                },
-                "j": {
-                  "label": "Orthophoto"
+                  "code": "i",
+                  "label": "Imaginative map",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Photo mosaic (controlled)"
+                  "code": "m",
+                  "label": "Photo mosaic (controlled)",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Photo mosaic (uncontrolled)"
+                  "code": "n",
+                  "label": "Photo mosaic (uncontrolled)",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Photomap"
+                  "code": "o",
+                  "label": "Photomap",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Plan"
+                  "code": "p",
+                  "label": "Plan",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Space remote-sensing image"
+                  "code": "t",
+                  "label": "Space remote-sensing image",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "Terrestrial remote-sensing image"
+                  "code": "v",
+                  "label": "Terrestrial remote-sensing image",
+                  "deprecated": true
                 },
                 "w": {
-                  "label": "Topographical drawing"
+                  "code": "w",
+                  "label": "Topographical drawing",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Topographical print"
+                  "code": "x",
+                  "label": "Topographical print",
+                  "deprecated": true
                 }
               }
             },
@@ -3466,18 +4347,21 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Multicolored [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Multicolored [OBSOLETE, 1982]",
+                  "deprecated": true
                 }
               }
             },
@@ -3489,72 +4373,95 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Paper"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Wood"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Stone"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Metal"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Glass"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Flexible base photographic, positive"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Flexible base photographic, negative"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Non-flexible base photographic, positive"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Non-flexible base photographic, negative"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Not Applicable"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Other photographic medium"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3567,18 +4474,23 @@
               "repeatableContent": false,
               "codes": {
                 "f": {
+                  "code": "f",
                   "label": "Facsimile"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3591,24 +4503,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Photocopy, blueline print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Photocopy"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Photographic pre-production"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Film"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3621,24 +4540,29 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -3654,39 +4578,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Aperture card"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfilm cartridge"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microfilm cassette"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Microfilm reel"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Microfiche"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Microfiche cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Microopaque"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Microfilm slip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Microfilm roll"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3699,18 +4635,23 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed polarity"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3723,39 +4664,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "h": {
+                  "code": "h",
                   "label": "105 mm."
                 },
                 "l": {
+                  "code": "l",
                   "label": "3x5 in. or 8x13 cm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "4x6 in. or 11x15 cm."
                 },
                 "o": {
+                  "code": "o",
                   "label": "6x9 in. or 16x23 cm."
                 },
                 "p": {
+                  "code": "p",
                   "label": "3 1/4 x 7 3/8 in. or 9x19 cm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3768,27 +4721,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low reduction ratio"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Normal reduction"
                 },
                 "c": {
+                  "code": "c",
                   "label": "High reduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Very high reduction"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Ultra high reduction"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Reduction rate varies"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3808,21 +4769,27 @@
               "repeatableContent": false,
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3835,27 +4802,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Silver halide"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Diazo"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vesicular"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed emulsion"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3868,21 +4843,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "First generation (master)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Printing master"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Service copy"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed generation"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3895,45 +4876,57 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "b": {
-                  "label": "Not safety base [OBSOLETE, 1991]"
+                  "code": "b",
+                  "label": "Not safety base [OBSOLETE, 1991]",
+                  "deprecated": true
                 }
               }
             }
@@ -3949,24 +4942,31 @@
               "repeatableContent": false,
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Film cartridge"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Film cassette"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Film roll"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Film reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -3979,27 +4979,35 @@
               "repeatableContent": false,
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4012,36 +5020,45 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard sound aperture (reduced frame)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nonanamorphic (wide-screen)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "3D"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Anamorphic (wide-screen)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Other wide-screen format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Standard silent aperture (full frame)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1983]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1983]",
+                  "deprecated": true
                 }
               }
             },
@@ -4053,18 +5070,23 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4077,42 +5099,55 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Optical and magnetic sound track on motion picture film"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4125,33 +5160,43 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm."
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm."
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm."
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm."
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm."
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm."
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4164,27 +5209,35 @@
               "repeatableContent": false,
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4197,39 +5250,49 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Workprint"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Trims"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Outtakes"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Rushes"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Mixing tracks"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Title bands/inter-title rolls"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Production rolls"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Other [OBSOLETE, 1988]"
+                  "code": "h",
+                  "label": "Other [OBSOLETE, 1988]",
+                  "deprecated": true
                 }
               }
             },
@@ -4241,21 +5304,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Positive"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Negative"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4268,24 +5337,31 @@
               "repeatableContent": false,
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Duplicate"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Master"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Original"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reference print/viewing copy"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4298,39 +5374,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Safety base, undetermined"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Safety base, acetate undetermined"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Safety base, diacetate"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Nitrate base"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed base (nitrate and safety)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Safety base, polyester"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Safety base, mixed"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Safety base, triacetate"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4343,72 +5431,95 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 layer color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "2 color, single strip"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Undetermined 2 color"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Undetermined 3 color"
                 },
                 "e": {
+                  "code": "e",
                   "label": "3 strip color"
                 },
                 "f": {
+                  "code": "f",
                   "label": "2 strip color"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Red strip"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blue or green strip"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Cyan strip"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Magenta strip"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Yellow strip"
                 },
                 "l": {
+                  "code": "l",
                   "label": "S E N 2"
                 },
                 "m": {
+                  "code": "m",
                   "label": "S E N 3"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Sepia tone"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Other tone"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Tint"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Tinted and toned"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Stencil color"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Hand colored"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4421,27 +5532,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Imbibition dye transfer prints"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Three-layer stock"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Three layer stock, low fade"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Duplitized stock"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4454,39 +5573,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "None apparent"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Nitrate: suspicious odor"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Nitrate: pungent odor"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Nitrate: brownish, discoloration, fading, dusty"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Nitrate: sticky"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Nitrate: frothy, bubbles, blisters"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Nitrate: congealed"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Nitrate: powder"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Non-nitrate: detectable deterioration"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Non-nitrate: advanced deterioration"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Non-nitrate: disaster"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4499,18 +5630,23 @@
               "repeatableContent": false,
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Complete"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Incomplete"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4534,66 +5670,87 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Activity card"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drawing"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Painting"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Photomechanical print"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Photonegative"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Photoprint"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Print"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Poster"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Postcard"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Icon"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Radiograph"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Study print"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Photograph, type unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4606,27 +5763,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4639,72 +5804,95 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4717,75 +5905,99 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Canvas"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bristol board"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard/illustration board"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Skin"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Textile"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Plastic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vinyl"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Vellum"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plaster"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hardboard"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Porcelain"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stone"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Wood"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Leather"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Parchment"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4802,9 +6014,11 @@
               "repeatableContent": false,
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4821,39 +6035,50 @@
               "repeatableContent": false,
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Filmstrip cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Filmslip"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip, type unspecified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Filmstrip roll"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981] [USMARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -4865,30 +6090,39 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hand colored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4901,39 +6135,50 @@
               "repeatableContent": false,
               "codes": {
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Safety film"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Film base, other than safety film"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Paper"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -4945,18 +6190,23 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -4969,48 +6219,57 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1981]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1981]"
                 }
               }
             },
@@ -5022,66 +6281,78 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Standard 8 mm. film width"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Super 8 mm./single 8 mm. film width"
                 },
                 "c": {
+                  "code": "c",
                   "label": "9.5 mm. film width"
                 },
                 "d": {
+                  "code": "d",
                   "label": "16 mm. film width"
                 },
                 "e": {
+                  "code": "e",
                   "label": "28 mm. film width"
                 },
                 "f": {
+                  "code": "f",
                   "label": "35 mm. film width"
                 },
                 "g": {
+                  "code": "g",
                   "label": "70 mm. film width"
                 },
                 "j": {
+                  "code": "j",
                   "label": "2x2 in. or 5x5 cm. slide"
                 },
                 "k": {
+                  "code": "k",
                   "label": "2 1/4 x 2 1/4 in. or 6x6 cm. slide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "4x5 in. or 10x13 cm. transparency"
                 },
                 "t": {
+                  "code": "t",
                   "label": "5x7 in. or 13x18 cm. transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "8x10 in. or 21x26 cm. transparency"
                 },
                 "w": {
+                  "code": "w",
                   "label": "9x9 in. or 23x23 cm. transparency"
                 },
                 "x": {
+                  "code": "x",
                   "label": "10x10 in. or 26x26 cm. transparency"
                 },
                 "y": {
-                  "label": "7x7 in. or 18x18 cm. transparency"
+                  "code": "y",
+                  "label": "Unknown [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "u": {
-                  "label": "Unknown"
+                  "code": "u",
+                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "u": {
-                  "label": "7x7 in. or 18x18 cm. [OBSOLETE, 1980]"
-                },
-                "y": {
-                  "label": "Unknown [OBSOLETE, 1980]"
                 }
               }
             },
@@ -5093,36 +6364,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No secondary support"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cardboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Glass"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Synthetic"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Metal"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Metal and glass"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Synthetic and glass"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed collection"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5139,15 +6421,17 @@
               "repeatableContent": false,
               "codes": {
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "No type specified [OBSOLETE, 1998]"
+                  "code": " ",
+                  "label": "No type specified [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             },
@@ -5159,24 +6443,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Surface"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Airborne"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Spaceborne"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5189,21 +6480,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Low oblique"
                 },
                 "b": {
+                  "code": "b",
                   "label": "High oblique"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Vertical"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5216,42 +6513,55 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "0-9%"
                 },
                 "1": {
+                  "code": "1",
                   "label": "10-19%"
                 },
                 "2": {
+                  "code": "2",
                   "label": "20-29%"
                 },
                 "3": {
+                  "code": "3",
                   "label": "30-39%"
                 },
                 "4": {
+                  "code": "4",
                   "label": "40-49%"
                 },
                 "5": {
+                  "code": "5",
                   "label": "50-59%"
                 },
                 "6": {
+                  "code": "6",
                   "label": "60-69%"
                 },
                 "7": {
+                  "code": "7",
                   "label": "70-79%"
                 },
                 "8": {
+                  "code": "8",
                   "label": "80-89%"
                 },
                 "9": {
+                  "code": "9",
                   "label": "90-100%"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5264,42 +6574,55 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Balloon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Aircraft--low altitude"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Aircraft--medium altitude"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Aircraft--high altitude"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manned spacecraft"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Unmanned spacecraft"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Land-based remote-sensing device"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Water surface-based remote-sensing device"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Submersible remote-sensing device"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5312,27 +6635,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Meteorological"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Surface observing"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Space observing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed uses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5345,18 +6676,23 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Active"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Passive"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5369,129 +6705,171 @@
               "repeatableContent": false,
               "codes": {
                 "aa": {
+                  "code": "aa",
                   "label": "Visible light"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Near infrared"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Middle infrared"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Far infrared"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Thermal infrared"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Shortwave infrared (SWIR)"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Reflective infrared"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Combinations"
                 },
                 "dz": {
+                  "code": "dz",
                   "label": "Other infrared data"
                 },
                 "ga": {
+                  "code": "ga",
                   "label": "Sidelooking airborne radar (SLAR)"
                 },
                 "gb": {
+                  "code": "gb",
                   "label": "Synthetic aperture radar (SAR)-Single frequency"
                 },
                 "gc": {
+                  "code": "gc",
                   "label": "SAR-multi-frequency (multichannel)"
                 },
                 "gd": {
+                  "code": "gd",
                   "label": "SAR-like polarization"
                 },
                 "ge": {
+                  "code": "ge",
                   "label": "SAR-cross polarization"
                 },
                 "gf": {
+                  "code": "gf",
                   "label": "Infometric SAR"
                 },
                 "gg": {
+                  "code": "gg",
                   "label": "polarmetric SAR"
                 },
                 "gu": {
+                  "code": "gu",
                   "label": "Passive microwave mapping"
                 },
                 "gz": {
+                  "code": "gz",
                   "label": "Other microwave data"
                 },
                 "ja": {
+                  "code": "ja",
                   "label": "Far ultraviolet"
                 },
                 "jb": {
+                  "code": "jb",
                   "label": "Middle ultraviolet"
                 },
                 "jc": {
+                  "code": "jc",
                   "label": "Near ultraviolet"
                 },
                 "jv": {
+                  "code": "jv",
                   "label": "Ultraviolet combinations"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Other ultraviolet data"
                 },
                 "ma": {
+                  "code": "ma",
                   "label": "Multi-spectral, multidata"
                 },
                 "mb": {
+                  "code": "mb",
                   "label": "Multi-temporal"
                 },
                 "mm": {
+                  "code": "mm",
                   "label": "Combination of various data types"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "pa": {
+                  "code": "pa",
                   "label": "Sonar--water depth"
                 },
                 "pb": {
+                  "code": "pb",
                   "label": "Sonar--bottom topography images, sidescan"
                 },
                 "pc": {
+                  "code": "pc",
                   "label": "Sonar--bottom topography, near-surface"
                 },
                 "pd": {
+                  "code": "pd",
                   "label": "Sonar--bottom topography, near-bottom"
                 },
                 "pe": {
+                  "code": "pe",
                   "label": "Seismic surveys"
                 },
                 "pz": {
+                  "code": "pz",
                   "label": "Other acoustical data"
                 },
                 "ra": {
+                  "code": "ra",
                   "label": "Gravity anomalies (general)"
                 },
                 "rb": {
+                  "code": "rb",
                   "label": "Free-air"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Bouger"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Isostatic"
                 },
                 "sa": {
+                  "code": "sa",
                   "label": "Magnetic field"
                 },
                 "ta": {
+                  "code": "ta",
                   "label": "radiometric surveys"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -5508,54 +6886,67 @@
               "repeatableContent": false,
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "Belt"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Cylinder"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Sound cartridge"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Sound-track film"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Roll"
                 },
                 "r": {
-                  "label": "Remote"
+                  "code": "r",
+                  "label": "Roll [OBSOLETE]",
+                  "deprecated": true
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sound cassette"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Sound-tape reel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wire recording"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "c": {
-                  "label": "Cylinder [OBSOLETE]"
+                  "code": "c",
+                  "label": "Cylinder [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Sound-track film [OBSOLETE]"
-                },
-                "r": {
-                  "label": "Roll [OBSOLETE]"
+                  "code": "f",
+                  "label": "Sound-track film [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5567,57 +6958,75 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "16 rpm (discs)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "33 1/3 rpm (discs)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "45 rpm (discs)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "78 rpm (discs)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "8 rpm (discs)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "1.4 m. per second (discs)"
                 },
                 "h": {
+                  "code": "h",
                   "label": "120 rpm (cylinders)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "160 rpm (cylinders)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "15/16 ips (tapes)"
                 },
                 "l": {
+                  "code": "l",
                   "label": "1 7/8 ips (tapes)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "3 3/4 ips (tapes)"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "7 1/2 ips (tapes)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "15 ips (tapes)"
                 },
                 "r": {
+                  "code": "r",
                   "label": "30 ips (tape)"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5630,42 +7039,58 @@
               "repeatableContent": false,
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Acoustic [OBSOLETE]"
+                  "code": "a",
+                  "label": "Acoustic [OBSOLETE]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Monaural (digital) [OBSOLETE]"
+                  "code": "f",
+                  "label": "Monaural (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Quadraphonic (digital) [OBSOLETE]"
+                  "code": "g",
+                  "label": "Quadraphonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Stereophonic (digital) [OBSOLETE]"
+                  "code": "j",
+                  "label": "Stereophonic (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Other (digital) [OBSOLETE]"
+                  "code": "k",
+                  "label": "Other (digital) [OBSOLETE]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other (electric) [OBSOLETE]"
+                  "code": "o",
+                  "label": "Other (electric) [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5677,21 +7102,27 @@
               "repeatableContent": false,
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Microgroove/fine"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Coarse/standard"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5704,45 +7135,59 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "3 in. diameter"
                 },
                 "b": {
+                  "code": "b",
                   "label": "5 in. diameter"
                 },
                 "c": {
+                  "code": "c",
                   "label": "7 in. diameter"
                 },
                 "d": {
+                  "code": "d",
                   "label": "10 in. diameter"
                 },
                 "e": {
+                  "code": "e",
                   "label": "12 in. diameter"
                 },
                 "f": {
+                  "code": "f",
                   "label": "16 in. diameter"
                 },
                 "g": {
+                  "code": "g",
                   "label": "4 3/4 in. or 12 cm. diameter"
                 },
                 "j": {
+                  "code": "j",
                   "label": "3 7/8 x 2 1/2 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "5 1/4 x 3 7/8 in."
                 },
                 "s": {
+                  "code": "s",
                   "label": "2 3/4 x 4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5755,39 +7200,51 @@
               "repeatableContent": false,
               "codes": {
                 "l": {
+                  "code": "l",
                   "label": "1/8 in."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "1/4 in. [OBSOLETE]"
+                  "code": "a",
+                  "label": "1/4 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "1/2 in. [OBSOLETE]"
+                  "code": "b",
+                  "label": "1/2 in. [OBSOLETE]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "1 in. [OBSOLETE]"
+                  "code": "c",
+                  "label": "1 in. [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -5799,33 +7256,43 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full (1) track"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Half (2) track"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Quarter (4) track"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Eight track"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Twelve track"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Sixteen track"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5838,39 +7305,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Master tape"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Tape duplication master"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Disc master (negative)"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instantaneous (recorded on the spot)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mass-produced"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Mother (positive)"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stamper (negative)"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Test pressing"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5883,48 +7362,63 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Lacquer coating"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Cellulose nitrate"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Acetate tape with ferrous oxide"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Glass with lacquer"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Aluminum with lacquer"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Metal"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Plastic with metal"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Plastic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Paper with lacquer or ferrous oxide"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shellac"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Wax"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5937,18 +7431,23 @@
               "repeatableContent": false,
               "codes": {
                 "h": {
+                  "code": "h",
                   "label": "Hill-and-dale cutting"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lateral or combined cutting"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -5961,39 +7460,51 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "NAB standard"
                 },
                 "b": {
+                  "code": "b",
                   "label": "CCIR standard"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Dolby-B encoded"
                 },
                 "d": {
+                  "code": "d",
                   "label": "dbx encoded"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Digital recording"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Dolby-A encoded"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Dolby-C encoded"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CX encoded"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6006,24 +7517,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Acoustical capture, analog direct storage"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Electrical capture, analog direct storage"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Electrical capture, digital storage"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Electrical capture, analog electrical storage"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown capture and storage"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6040,24 +7558,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Moon"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Combination"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Tactile, with no writing system"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6071,36 +7596,47 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified class of braille writing"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Literary braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Format code braille"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Mathematics and scientific braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Computer braille"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Music braille"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple braille types"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6113,24 +7649,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Uncontracted"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Contracted"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6144,54 +7687,71 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified braille music format"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Bar over bar"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bar by bar"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Line over line"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Paragraph"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Single line"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Section by section"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Line by line"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Open score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Spanner short form scoring"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short form scoring"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Outline"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Vertical score"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6204,21 +7764,27 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Print/braille"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Jumbo or enlarged braille"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6235,24 +7801,31 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Regular print"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Large print"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Braille"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Loose-leaf"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6269,15 +7842,19 @@
               "repeatableContent": false,
               "codes": {
                 "m": {
+                  "code": "m",
                   "label": "Multiple physical forms"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6294,33 +7871,42 @@
               "repeatableContent": false,
               "codes": {
                 "c": {
+                  "code": "c",
                   "label": "Videocartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Videodisc"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Videocassette"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Videoreel"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unspecified"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6332,27 +7918,35 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "One color"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Black-and-white"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multicolored"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6365,72 +7959,94 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Beta (1/2 in., videocassette)"
                 },
                 "b": {
+                  "code": "b",
                   "label": "VHS (1/2 in., videocassette)"
                 },
                 "c": {
+                  "code": "c",
                   "label": "U-matic (3/4 in., videocasstte)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "EIAJ (1/2 in., reel)"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Type C (1 in., reel)"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Quadruplex (1 in. or 2 in., reel)"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Laserdisc"
                 },
                 "h": {
+                  "code": "h",
                   "label": "CED (Capacitance Electronic Disc) videodisc"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Betacam (1/2 in., videocassette)"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Betacam SP (1/2 in., videocassette)"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Super-VHS (1/2 in., videocassette)"
                 },
                 "m": {
+                  "code": "m",
                   "label": "M-II (1/2 in., videocassette)"
                 },
                 "o": {
+                  "code": "o",
                   "label": "D-2 (3/4 in., videocassette)"
                 },
                 "p": {
+                  "code": "p",
                   "label": "8 mm."
                 },
                 "q": {
+                  "code": "q",
                   "label": "Hi-8 mm."
                 },
                 "s": {
+                  "code": "s",
                   "label": "Blu-ray disc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "v": {
+                  "code": "v",
                   "label": "DVD"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable or no attempt to code [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6442,18 +8058,23 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Sound on medium"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Sound separate from medium"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6466,48 +8087,57 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No sound (silent)"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Optical sound track on motion picture film"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Magnetic sound track on motion picture film"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Magnetic audio tape in cartridge"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Sound disc"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Magnetic audio tape on reel"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Magnetic audio tape in cassette"
                 },
                 "g": {
-                  "label": "Optical and magnetic sound track on motion picture film"
+                  "code": "g",
+                  "label": "Other [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Videotape"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Videodisc"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Other [OBSOLETE, 1980]"
                 }
               }
             },
@@ -6519,36 +8149,45 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "8 mm."
                 },
                 "m": {
+                  "code": "m",
                   "label": "1/4 in."
                 },
                 "o": {
+                  "code": "o",
                   "label": "1/2 in."
                 },
                 "p": {
+                  "code": "p",
                   "label": "1 in."
                 },
                 "q": {
+                  "code": "q",
                   "label": "2 in."
                 },
                 "r": {
+                  "code": "r",
                   "label": "3/4 in."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "1/4 in. [OBSOLETE, 1981]"
+                  "code": "n",
+                  "label": "1/4 in. [OBSOLETE, 1981]",
+                  "deprecated": true
                 }
               }
             },
@@ -6560,27 +8199,35 @@
               "repeatableContent": false,
               "codes": {
                 "k": {
+                  "code": "k",
                   "label": "Mixed"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monaural"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quadraphonic, multichannel, or surround"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Stereophonic"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6611,48 +8258,63 @@
               "repeatableContent": false,
               "codes": {
                 "b": {
+                  "code": "b",
                   "label": "No dates given; B.C. date involved"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Continuing resource currently published"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Continuing resource ceased publication"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Detailed date"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Inclusive dates of collection"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Range of years of bulk of collection"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple dates"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Dates unknown"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Date of distribution/release/issue and production/recording session when different"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Questionable date"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Reprint/reissue date and original date"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Single known date/probable date"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Publication date and copyright date"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Continuing resource status unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6693,30 +8355,37 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not modified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dashed-on information omitted"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Completely romanized/printed cards romanized"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Completely romanized/printed cards in script"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Shortened"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Missing characters"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "Unknown [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "Unknown [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -6728,39 +8397,54 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "National bibliographic agency"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cooperative cataloging program"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Other"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]"
+                  "code": "a",
+                  "label": "National Agricultural Library [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]"
+                  "code": "b",
+                  "label": "National Library of Medicine [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "l",
+                  "label": "Library of Congress cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "o": {
-                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "o",
+                  "label": "Other institution cataloguing [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "n": {
-                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]"
+                  "code": "n",
+                  "label": "Report to New serials titles [OBSOLETE, 1997] [USMARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Reporting library [OBSOLETE, 1997] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             }
@@ -6777,54 +8461,71 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No illustrations"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Illustrations"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Maps"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Portraits"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Charts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Plans"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Plates"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Music"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Facsimiles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Coats of arms"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Genealogical tables"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Forms"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Samples"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Phonodisc, phonowire, etc."
                 },
                 "o": {
+                  "code": "o",
                   "label": "Photographs"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Illuminations"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -6837,42 +8538,54 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -6884,51 +8597,68 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -6941,105 +8671,140 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified nature of contents"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Patent document"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Offprints"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Handbooks [OBSOLETE]"
+                  "code": "h",
+                  "label": "Handbooks [OBSOLETE]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Technical reports [OBSOLETE, 1997]"
+                  "code": "x",
+                  "label": "Technical reports [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7051,45 +8816,57 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -7101,12 +8878,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7119,12 +8899,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a festschrift"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Festschrift"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7137,12 +8920,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7155,51 +8941,66 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not fiction (not further specified)"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Fiction (not further specified)"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dramas"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Novels"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Humor, satires, etc."
                 },
                 "i": {
+                  "code": "i",
                   "label": "Letters"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Short stories"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Mixed forms"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Speeches"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Non-fiction [OBSOLETE, 1997]"
+                  "code": " ",
+                  "label": "Non-fiction [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Comic strips [OBSOLETE, 2008]"
+                  "code": "c",
+                  "label": "Comic strips [OBSOLETE, 2008]",
+                  "deprecated": true
                 }
               }
             },
@@ -7211,21 +9012,27 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No biographical material"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Individual biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Collective biography"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Contains biographical information"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7242,33 +9049,43 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7281,15 +9098,19 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7302,45 +9123,59 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Numeric data"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Computer program"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Representational"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Document"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bibliographic data"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Font"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Sound"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Interactive multimedia"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Online system or service"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Combination"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7353,39 +9188,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7402,63 +9249,83 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No determinable frequency"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Annual"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bimonthly"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Semiweekly"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Daily"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biweekly"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Semiannual"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Biennial"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Triennial"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Three times a week"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Three times a month"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Continuously updated"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monthly"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Quarterly"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Semimonthly"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Three times a year"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Weekly"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7471,18 +9338,23 @@
               "repeatableContent": false,
               "codes": {
                 "n": {
+                  "code": "n",
                   "label": "Normalized irregular"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "x": {
+                  "code": "x",
                   "label": "Completely irregular"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7495,45 +9367,59 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Updating database"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Magazine"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Blog"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Journal"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Updating loose-leaf"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Monographic series"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Newspaper"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Periodical"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Repository"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Newsletter"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Directory"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Updating Web site"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7546,36 +9432,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Newspaper format"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7588,51 +9485,68 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             },
@@ -7644,96 +9558,126 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7746,96 +9690,126 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Abstracts/summaries"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliographies"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Catalogs"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Dictionaries"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Encyclopedias"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Handbooks"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Legal articles"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Biography"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Indexes"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Discographies"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Legislation"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Theses"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Surveys of literature in a subject area"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Reviews"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Programmed texts"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Filmographies"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Directories"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Statistics"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Technical reports"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Standards/specifications"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Legal cases and case notes"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Law reports and digests"
                 },
                 "y": {
+                  "code": "y",
                   "label": "Yearbooks"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Treaties"
                 },
                 "5": {
+                  "code": "5",
                   "label": "Calendars"
                 },
                 "6": {
+                  "code": "6",
                   "label": "Comics/graphic novels"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "3": {
-                  "label": "Discographies [OBSOLETE, 1997]"
+                  "code": "3",
+                  "label": "Discographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 },
                 "4": {
-                  "label": "Filmographies [OBSOLETE, 1997]"
+                  "code": "4",
+                  "label": "Filmographies [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -7847,45 +9821,57 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -7897,12 +9883,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Not a conference publication"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Conference publication"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7915,51 +9904,67 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No alphabet or script given/No key title"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Basic Roman"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Extended Roman"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Cyrillic"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Japanese"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Chinese"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Arabic"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Greek"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Hebrew"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Thai"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Devanagari"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Korean"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Tamil"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7972,15 +9977,19 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "Successive entry"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Latest entry"
                 },
                 "2": {
+                  "code": "2",
                   "label": "Integrated entry"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -7998,51 +10007,65 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No relief shown"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Contours"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Shading"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Gradient and bathymetric tints"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Hachures"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Bathymetry/soundings"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Form lines"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Spot heights"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Pictorially"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Land forms"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Bathymetry/isolines"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Rock drawings"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "h": {
-                  "label": "Color [OBSOLETE, 1980]"
+                  "code": "h",
+                  "label": "Color [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             },
@@ -8054,147 +10077,195 @@
               "repeatableContent": false,
               "codes": {
                 "  ": {
+                  "code": "  ",
                   "label": "Projection not specified"
                 },
                 "aa": {
+                  "code": "aa",
                   "label": "Aitoff"
                 },
                 "ab": {
+                  "code": "ab",
                   "label": "Gnomic"
                 },
                 "ac": {
+                  "code": "ac",
                   "label": "Lambert's azimuthal equal area"
                 },
                 "ad": {
+                  "code": "ad",
                   "label": "Orthographic"
                 },
                 "ae": {
+                  "code": "ae",
                   "label": "Azimuthal equidistant"
                 },
                 "af": {
+                  "code": "af",
                   "label": "Stereographic"
                 },
                 "ag": {
+                  "code": "ag",
                   "label": "General vertical near-sided"
                 },
                 "am": {
+                  "code": "am",
                   "label": "Modified stereographic for Alaska"
                 },
                 "an": {
+                  "code": "an",
                   "label": "Chamberlin trimetric"
                 },
                 "ap": {
+                  "code": "ap",
                   "label": "Polar stereographic"
                 },
                 "au": {
+                  "code": "au",
                   "label": "Azimuthal, specific type unknown"
                 },
                 "az": {
+                  "code": "az",
                   "label": "Azimuthal, other"
                 },
                 "ba": {
+                  "code": "ba",
                   "label": "Gall"
                 },
                 "bb": {
+                  "code": "bb",
                   "label": "Goode's homolographic"
                 },
                 "bc": {
+                  "code": "bc",
                   "label": "Lambert's cylindrical equal area"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Mercator"
                 },
                 "be": {
+                  "code": "be",
                   "label": "Miller"
                 },
                 "bf": {
+                  "code": "bf",
                   "label": "Mollweide"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Sinusoidal"
                 },
                 "bh": {
+                  "code": "bh",
                   "label": "Transverse Mercator"
                 },
                 "bi": {
+                  "code": "bi",
                   "label": "Gauss-Kruger"
                 },
                 "bj": {
+                  "code": "bj",
                   "label": "Equirectangular"
                 },
                 "bk": {
+                  "code": "bk",
                   "label": "Krovak"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Cassini-Soldner"
                 },
                 "bo": {
+                  "code": "bo",
                   "label": "Oblique Mercator"
                 },
                 "br": {
+                  "code": "br",
                   "label": "Robinson"
                 },
                 "bs": {
+                  "code": "bs",
                   "label": "Space oblique Mercator"
                 },
                 "bu": {
+                  "code": "bu",
                   "label": "Cylindrical, specific type unknown"
                 },
                 "bz": {
+                  "code": "bz",
                   "label": "Cylindrical, other"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Albers equal area"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Bonne"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Lambert's conformal conic"
                 },
                 "ce": {
+                  "code": "ce",
                   "label": "Equidistant conic"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Polyconic"
                 },
                 "cu": {
+                  "code": "cu",
                   "label": "Conic, specific type unknown"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Conic, other"
                 },
                 "da": {
+                  "code": "da",
                   "label": "Armadillo"
                 },
                 "db": {
+                  "code": "db",
                   "label": "Butterfly"
                 },
                 "dc": {
+                  "code": "dc",
                   "label": "Eckert"
                 },
                 "dd": {
+                  "code": "dd",
                   "label": "Goode's homolosine"
                 },
                 "de": {
+                  "code": "de",
                   "label": "Miller's bipolar oblique conformal conic"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Van Der Grinten"
                 },
                 "dg": {
+                  "code": "dg",
                   "label": "Dimaxion"
                 },
                 "dh": {
+                  "code": "dh",
                   "label": "Cordiform"
                 },
                 "dl": {
+                  "code": "dl",
                   "label": "Lambert conformal"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8207,33 +10278,43 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Single map"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Map series"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Map serial"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Globe"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Atlas"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Separate supplement to another work"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Bound as part of another work"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8246,39 +10327,51 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8291,36 +10384,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8333,12 +10437,15 @@
               "repeatableContent": false,
               "codes": {
                 "0": {
+                  "code": "0",
                   "label": "No index"
                 },
                 "1": {
+                  "code": "1",
                   "label": "Index present"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8352,66 +10459,93 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No specified special format characteristics"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Manuscript"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Picture card, post card"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Calendar"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Puzzle"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Game"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Wall map"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Playing cards"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Loose-leaf"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Photocopy, blue line print [OBSOLETE, 1982]"
+                  "code": "a",
+                  "label": "Photocopy, blue line print [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "b": {
-                  "label": "Photocopy [OBSOLETE, 1982]"
+                  "code": "b",
+                  "label": "Photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "c": {
-                  "label": "Negative photocopy [OBSOLETE, 1982]"
+                  "code": "c",
+                  "label": "Negative photocopy [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "d": {
-                  "label": "Film negative [OBSOLETE, 1982]"
+                  "code": "d",
+                  "label": "Film negative [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "f": {
-                  "label": "Facsimile [OBSOLETE, 1982]"
+                  "code": "f",
+                  "label": "Facsimile [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "Relief model [OBSOLETE, 1982]"
+                  "code": "g",
+                  "label": "Relief model [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Rare [OBSOLETE, 1982]"
+                  "code": "h",
+                  "label": "Rare [OBSOLETE, 1982]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Braille [OBSOLETE, 1998]"
+                  "code": "m",
+                  "label": "Braille [OBSOLETE, 1998]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Large print [OBSOLETE, 1998]"
+                  "code": "q",
+                  "label": "Large print [OBSOLETE, 1998]",
+                  "deprecated": true
                 }
               }
             }
@@ -8427,60 +10561,83 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Handwritten transcript [OBSOLETE, 1987]"
+                  "code": "j",
+                  "label": "Handwritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Photocopy [OBSOLETE, 1987]"
+                  "code": "p",
+                  "label": "Photocopy [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Typewritten transcript [OBSOLETE, 1987]"
+                  "code": "t",
+                  "label": "Typewritten transcript [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE, 1987]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE, 1987]",
+                  "deprecated": true
                 }
               }
             }
@@ -8496,222 +10653,295 @@
               "repeatableContent": false,
               "codes": {
                 "an": {
+                  "code": "an",
                   "label": "Anthems"
                 },
                 "bd": {
+                  "code": "bd",
                   "label": "Ballads"
                 },
                 "bg": {
+                  "code": "bg",
                   "label": "Bluegrass music"
                 },
                 "bl": {
+                  "code": "bl",
                   "label": "Blues"
                 },
                 "bt": {
+                  "code": "bt",
                   "label": "Ballets"
                 },
                 "ca": {
+                  "code": "ca",
                   "label": "Chaconnes"
                 },
                 "cb": {
+                  "code": "cb",
                   "label": "Chants, Other religions"
                 },
                 "cc": {
+                  "code": "cc",
                   "label": "Chant, Christian"
                 },
                 "cg": {
+                  "code": "cg",
                   "label": "Concerti grossi"
                 },
                 "ch": {
+                  "code": "ch",
                   "label": "Chorales"
                 },
                 "cl": {
+                  "code": "cl",
                   "label": "Chorale preludes"
                 },
                 "cn": {
+                  "code": "cn",
                   "label": "Canons and rounds"
                 },
                 "co": {
+                  "code": "co",
                   "label": "Concertos"
                 },
                 "cp": {
+                  "code": "cp",
                   "label": "Chansons, polyphonic"
                 },
                 "cr": {
+                  "code": "cr",
                   "label": "Carols"
                 },
                 "cs": {
+                  "code": "cs",
                   "label": "Chance compositions"
                 },
                 "ct": {
+                  "code": "ct",
                   "label": "Cantatas"
                 },
                 "cy": {
+                  "code": "cy",
                   "label": "Country music"
                 },
                 "cz": {
+                  "code": "cz",
                   "label": "Canzonas"
                 },
                 "df": {
+                  "code": "df",
                   "label": "Dance forms"
                 },
                 "dv": {
+                  "code": "dv",
                   "label": "Divertimentos, serenades, cassations, divertissements, and notturni"
                 },
                 "fg": {
+                  "code": "fg",
                   "label": "Fugues"
                 },
                 "fl": {
+                  "code": "fl",
                   "label": "Flamenco"
                 },
                 "fm": {
+                  "code": "fm",
                   "label": "Folk music"
                 },
                 "ft": {
+                  "code": "ft",
                   "label": "Fantasias"
                 },
                 "gm": {
+                  "code": "gm",
                   "label": "Gospel music"
                 },
                 "hy": {
+                  "code": "hy",
                   "label": "Hymns"
                 },
                 "jz": {
+                  "code": "jz",
                   "label": "Jazz"
                 },
                 "mc": {
+                  "code": "mc",
                   "label": "Musical revues and comedies"
                 },
                 "md": {
+                  "code": "md",
                   "label": "Madrigals"
                 },
                 "mi": {
+                  "code": "mi",
                   "label": "Minuets"
                 },
                 "mo": {
+                  "code": "mo",
                   "label": "Motets"
                 },
                 "mp": {
+                  "code": "mp",
                   "label": "Motion picture music"
                 },
                 "mr": {
+                  "code": "mr",
                   "label": "Marches"
                 },
                 "ms": {
+                  "code": "ms",
                   "label": "Masses"
                 },
                 "mu": {
+                  "code": "mu",
                   "label": "Multiple forms"
                 },
                 "mz": {
+                  "code": "mz",
                   "label": "Mazurkas"
                 },
                 "nc": {
+                  "code": "nc",
                   "label": "Nocturnes"
                 },
                 "nn": {
+                  "code": "nn",
                   "label": "Not applicable"
                 },
                 "op": {
+                  "code": "op",
                   "label": "Operas"
                 },
                 "or": {
+                  "code": "or",
                   "label": "Oratorios"
                 },
                 "ov": {
+                  "code": "ov",
                   "label": "Overtures"
                 },
                 "pg": {
+                  "code": "pg",
                   "label": "Program music"
                 },
                 "pm": {
+                  "code": "pm",
                   "label": "Passion music"
                 },
                 "po": {
+                  "code": "po",
                   "label": "Polonaises"
                 },
                 "pp": {
+                  "code": "pp",
                   "label": "Popular music"
                 },
                 "pr": {
+                  "code": "pr",
                   "label": "Preludes"
                 },
                 "ps": {
+                  "code": "ps",
                   "label": "Passacaglias"
                 },
                 "pt": {
+                  "code": "pt",
                   "label": "Part-songs"
                 },
                 "pv": {
+                  "code": "pv",
                   "label": "Pavans"
                 },
                 "rc": {
+                  "code": "rc",
                   "label": "Rock music"
                 },
                 "rd": {
+                  "code": "rd",
                   "label": "Rondos"
                 },
                 "rg": {
+                  "code": "rg",
                   "label": "Ragtime music"
                 },
                 "ri": {
+                  "code": "ri",
                   "label": "Ricercars"
                 },
                 "rp": {
+                  "code": "rp",
                   "label": "Rhapsodies"
                 },
                 "rq": {
+                  "code": "rq",
                   "label": "Requiems"
                 },
                 "sd": {
+                  "code": "sd",
                   "label": "Square dance music"
                 },
                 "sg": {
+                  "code": "sg",
                   "label": "Songs"
                 },
                 "sn": {
+                  "code": "sn",
                   "label": "Sonatas"
                 },
                 "sp": {
+                  "code": "sp",
                   "label": "Symphonic poems"
                 },
                 "st": {
+                  "code": "st",
                   "label": "Studies and exercises"
                 },
                 "su": {
+                  "code": "su",
                   "label": "Suites"
                 },
                 "sy": {
+                  "code": "sy",
                   "label": "Symphonies"
                 },
                 "tc": {
+                  "code": "tc",
                   "label": "Toccatas"
                 },
                 "tl": {
+                  "code": "tl",
                   "label": "Teatro lirico"
                 },
                 "ts": {
+                  "code": "ts",
                   "label": "Trio-sonatas"
                 },
                 "uu": {
+                  "code": "uu",
                   "label": "Unknown"
                 },
                 "vi": {
+                  "code": "vi",
                   "label": "Villancicos"
                 },
                 "vr": {
+                  "code": "vr",
                   "label": "Variations"
                 },
                 "wz": {
+                  "code": "wz",
                   "label": "Waltzes"
                 },
                 "za": {
+                  "code": "za",
                   "label": "Zarzuelas"
                 },
                 "zz": {
+                  "code": "zz",
                   "label": "Other"
                 },
                 "||": {
+                  "code": "||",
                   "label": "No attempt to code"
                 }
               }
@@ -8724,54 +10954,71 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Full score"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Miniature or study score"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Accompaniment reduced for keyboard"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Voice score with accompaniment omitted"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Condensed score or piano-conductor score"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Close score"
                 },
                 "h": {
+                  "code": "h",
                   "label": "Chorus score"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Condensed score"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Performer-conductor part"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Vocal score"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Score"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multiple score formats"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Piano score"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -8784,30 +11031,37 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No parts in hand or not specified"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Instrumental and vocal parts"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Instrumental parts"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Vocal parts"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "a": {
-                  "label": "Parts exist"
+                  "code": "a",
+                  "label": "Parts exist",
+                  "deprecated": true
                 }
               }
             },
@@ -8819,42 +11073,54 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or unspecified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Specialized"
                 },
                 "g": {
+                  "code": "g",
                   "label": "General"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "u": {
-                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]"
+                  "code": "u",
+                  "label": "School material at first level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "v": {
-                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]"
+                  "code": "v",
+                  "label": "School material at second level [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -8866,54 +11132,73 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
-                  "label": "Magnetic tape [OBSOLETE, 1987]"
+                  "code": "h",
+                  "label": "Magnetic tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "i": {
-                  "label": "Multimedia [OBSOLETE, 1987]"
+                  "code": "i",
+                  "label": "Multimedia [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "x": {
-                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]"
+                  "code": "x",
+                  "label": "Other form of reproduction [OBSOLETE] [USMARC only]",
+                  "deprecated": true
                 },
                 "z": {
-                  "label": "Other form of reproduction [OBSOLETE]"
+                  "code": "z",
+                  "label": "Other form of reproduction [OBSOLETE]",
+                  "deprecated": true
                 }
               }
             },
@@ -8926,63 +11211,80 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "No accompanying matter"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Discography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Bibliography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Thematic index"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Libretto or text"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Biography of composer or author"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Biography of performer or history of ensemble"
                 },
                 "g": {
-                  "label": "Technical and/or historical information on instruments"
+                  "code": "g",
+                  "label": "Punched paper tape [OBSOLETE, 1987]",
+                  "deprecated": true
                 },
                 "h": {
+                  "code": "h",
                   "label": "Technical information on music"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Historical information"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Ethnological information"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Instructional materials"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Music"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "g": {
-                  "label": "Punched paper tape [OBSOLETE, 1987]"
                 },
                 "n": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": "n",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "j": {
-                  "label": "Historical information other than music [OBSOLETE, 1980]"
+                  "code": "j",
+                  "label": "Historical information other than music [OBSOLETE, 1980]",
+                  "deprecated": true
                 },
                 "l": {
-                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]"
+                  "code": "l",
+                  "label": "Biography of arranger or transcriber [OBSOLETE, 1997]",
+                  "deprecated": true
                 }
               }
             },
@@ -8995,69 +11297,91 @@
               "unitLength": 1,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Item is a music sound recording"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autobiography"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Biography"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Conference proceedings"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Drama"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Essays"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Fiction"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Reporting"
                 },
                 "h": {
+                  "code": "h",
                   "label": "History"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Instruction"
                 },
                 "j": {
+                  "code": "j",
                   "label": "Language instruction"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Comedy"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Lectures, speeches"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Memoirs"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Folktales"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Poetry"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Rehearsals"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Sounds"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Interviews"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9070,24 +11394,31 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not arrangement or transposition or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Transposition"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Arrangement"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Both transposed and arranged"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9104,18 +11435,23 @@
               "repeatableContent": false,
               "codes": {
                 "000": {
+                  "code": "000",
                   "label": "Running time exceeds three characters"
                 },
                 "001-999": {
+                  "code": "001-999",
                   "label": "Running time"
                 },
                 "nnn": {
+                  "code": "nnn",
                   "label": "Not applicable"
                 },
                 "---": {
+                  "code": "---",
                   "label": "Unknown"
                 },
                 "|||": {
+                  "code": "|||",
                   "label": "No attempt to code"
                 }
               }
@@ -9128,66 +11464,86 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Unknown or not specified"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Preschool"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Primary"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Pre-adolescent"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Adolescent"
                 },
                 "e": {
+                  "code": "e",
                   "label": "Adult"
                 },
                 "f": {
-                  "label": "Specialized"
+                  "code": "f",
+                  "label": "General [OBSOLETE]",
+                  "deprecated": true
                 },
                 "g": {
-                  "label": "General"
+                  "code": "g",
+                  "label": "Specialized [OBSOLETE]",
+                  "deprecated": true
                 },
                 "j": {
+                  "code": "j",
                   "label": "Juvenile"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
-                "f": {
-                  "label": "General [OBSOLETE]"
-                },
-                "g": {
-                  "label": "Specialized [OBSOLETE]"
                 },
                 "h": {
-                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]"
+                  "code": "h",
+                  "label": "Secondary (grades 10-12) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "k": {
-                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]"
+                  "code": "k",
+                  "label": "Preschool and Kindergarten [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "m": {
-                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]"
+                  "code": "m",
+                  "label": "Primary (grades 4-6) [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "p": {
-                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]"
+                  "code": "p",
+                  "label": "Special education - general [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "q": {
-                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]"
+                  "code": "q",
+                  "label": "Physically handicapped [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "r": {
-                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]"
+                  "code": "r",
+                  "label": "Mentally retarded [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "s": {
-                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]"
+                  "code": "s",
+                  "label": "Simplified works for adults [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 },
                 "t": {
-                  "label": "Gifted [OBSOLETE] [CAN/MARC only]"
+                  "code": "t",
+                  "label": "Gifted [OBSOLETE] [CAN/MARC only]",
+                  "deprecated": true
                 }
               }
             },
@@ -9199,45 +11555,57 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "Not a government publication"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Autonomous or semi-autonomous component"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Multilocal"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Federal/national"
                 },
                 "i": {
+                  "code": "i",
                   "label": "International intergovernmental"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Local"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Multistate"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Government publication-level undetermined"
                 },
                 "s": {
+                  "code": "s",
                   "label": "State, provincial, territorial, dependent, etc."
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown if item is government publication"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "n": {
-                  "label": "Government publication-level undetermined [OBSOLETE, 1979]"
+                  "code": "n",
+                  "label": "Government publication-level undetermined [OBSOLETE, 1979]",
+                  "deprecated": true
                 }
               }
             },
@@ -9249,36 +11617,47 @@
               "repeatableContent": false,
               "codes": {
                 " ": {
+                  "code": " ",
                   "label": "None of the following"
                 },
                 "a": {
+                  "code": "a",
                   "label": "Microfilm"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Microfiche"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Microopaque"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Large print"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Braille"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Online"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Direct electronic"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Regular print reproduction"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Electronic"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
                 }
               }
@@ -9291,72 +11670,93 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Art original"
                 },
                 "b": {
+                  "code": "b",
                   "label": "Kit"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Art reproduction"
                 },
                 "d": {
+                  "code": "d",
                   "label": "Diorama"
                 },
                 "f": {
+                  "code": "f",
                   "label": "Filmstrip"
                 },
                 "g": {
+                  "code": "g",
                   "label": "Game"
                 },
                 "i": {
+                  "code": "i",
                   "label": "Picture"
                 },
                 "k": {
+                  "code": "k",
                   "label": "Graphic"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Technical drawing"
                 },
                 "m": {
+                  "code": "m",
                   "label": "Motion picture"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Chart"
                 },
                 "o": {
+                  "code": "o",
                   "label": "Flash card"
                 },
                 "p": {
+                  "code": "p",
                   "label": "Microscope slide"
                 },
                 "q": {
+                  "code": "q",
                   "label": "Model"
                 },
                 "r": {
+                  "code": "r",
                   "label": "Realia"
                 },
                 "s": {
+                  "code": "s",
                   "label": "Slide"
                 },
                 "t": {
+                  "code": "t",
                   "label": "Transparency"
                 },
                 "v": {
+                  "code": "v",
                   "label": "Videorecording"
                 },
                 "w": {
+                  "code": "w",
                   "label": "Toy"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 "e": {
-                  "label": "Electronic videorecording [OBSOLETE, 1975]"
+                  "code": "e",
+                  "label": "Electronic videorecording [OBSOLETE, 1975]",
+                  "deprecated": true
                 }
               }
             },
@@ -9368,30 +11768,37 @@
               "repeatableContent": false,
               "codes": {
                 "a": {
+                  "code": "a",
                   "label": "Animation"
                 },
                 "c": {
+                  "code": "c",
                   "label": "Animation and live action"
                 },
                 "l": {
+                  "code": "l",
                   "label": "Live action"
                 },
                 "n": {
+                  "code": "n",
                   "label": "Not applicable"
                 },
                 "u": {
+                  "code": "u",
                   "label": "Unknown"
                 },
                 "z": {
+                  "code": "z",
                   "label": "Other"
                 },
                 "|": {
+                  "code": "|",
                   "label": "No attempt to code"
-                }
-              },
-              "historical-codes": {
+                },
                 " ": {
-                  "label": "Not applicable [OBSOLETE, 1980]"
+                  "code": " ",
+                  "label": "Not applicable [OBSOLETE, 1980]",
+                  "deprecated": true
                 }
               }
             }
@@ -9515,9 +11922,11 @@
         "label": "National bibliographic agency",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library and Archives Canada"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -9553,9 +11962,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Copyright or legal deposit number"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -9652,11 +12063,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Binding information (BK, MP, MU) [OBSOLETE]"
+          "label": "Binding information (BK, MP, MU) [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -9669,12 +12079,15 @@
         "label": "Level of international interest",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "0": {
+            "code": "0",
             "label": "Continuing resource of international interest"
           },
           "1": {
+            "code": "1",
             "label": "Continuing resource not of international interest"
           }
         }
@@ -9722,14 +12135,14 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Form of issue [OBSOLETE] [CAN/MARC only]"
+          "label": "Form of issue [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         },
         "c": {
-          "label": "Price [OBSOLETE] [CAN/MARC only]"
+          "label": "Price [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -9742,24 +12155,31 @@
         "label": "Type of standard number or code",
         "codes": {
           "0": {
+            "code": "0",
             "label": "International Standard Recording Code"
           },
           "1": {
+            "code": "1",
             "label": "Universal Product Code"
           },
           "2": {
+            "code": "2",
             "label": "International Standard Music Number"
           },
           "3": {
+            "code": "3",
             "label": "International Article Number"
           },
           "4": {
+            "code": "4",
             "label": "Serial Item and Contribution Identifier"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Unspecified type of standard number or code"
           }
         }
@@ -9768,12 +12188,15 @@
         "label": "Difference indicator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No difference"
           },
           "1": {
+            "code": "1",
             "label": "Difference"
           }
         }
@@ -9812,11 +12235,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Additional codes following the standard number [OBSOLETE]"
+          "label": "Additional codes following the standard number [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -9927,24 +12349,31 @@
         "label": "Type of number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Issue number"
           },
           "1": {
+            "code": "1",
             "label": "Matrix number"
           },
           "2": {
+            "code": "2",
             "label": "Plate number"
           },
           "3": {
+            "code": "3",
             "label": "Other music publisher number"
           },
           "4": {
+            "code": "4",
             "label": "Video recording publisher number"
           },
           "5": {
+            "code": "5",
             "label": "Other publisher number"
           },
           "6": {
+            "code": "6",
             "label": "Distributor number"
           }
         }
@@ -9953,15 +12382,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "Note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -10145,15 +12578,19 @@
         "label": "Type of date in subfield $a",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No date information"
           },
           "0": {
+            "code": "0",
             "label": "Single date"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates"
           }
         }
@@ -10162,15 +12599,19 @@
         "label": "Type of event",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Capture"
           },
           "1": {
+            "code": "1",
             "label": "Broadcast"
           },
           "2": {
+            "code": "2",
             "label": "Finding"
           }
         }
@@ -10230,18 +12671,21 @@
         "label": "Type of scale",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Scale indeterminable/No scale recorded"
           },
           "1": {
+            "code": "1",
             "label": "Single scale"
           },
           "3": {
+            "code": "3",
             "label": "Range of scales"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Two or more scales (BK, MP, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -10249,12 +12693,15 @@
         "label": "Type of ring",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Outer ring"
           },
           "1": {
+            "code": "1",
             "label": "Exclusion ring"
           }
         }
@@ -10429,12 +12876,15 @@
         "label": "Source of acquisition sequence",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -10561,12 +13011,15 @@
         "label": "Translation indication",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item not a translation/does not include a translation"
           },
           "1": {
+            "code": "1",
             "label": "Item is or includes a translation"
           }
         }
@@ -10575,9 +13028,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -10683,11 +13138,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]"
+          "label": "Languages of separate titles (VM) [OBSOLETE, 1972], Languages of available translation (SE) [OBSOLETE, 1977]",
+          "deprecated": true
         }
       }
     },
@@ -10798,15 +13252,19 @@
         "label": "Type of time period in subfield $b or $c",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Subfield $b or $c not present"
           },
           "0": {
+            "code": "0",
             "label": "Single date/time"
           },
           "1": {
+            "code": "1",
             "label": "Multiple single dates/times"
           },
           "2": {
+            "code": "2",
             "label": "Range of dates/times"
           }
         }
@@ -10845,15 +13303,19 @@
         "label": "Type of entity",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Work"
           },
           "2": {
+            "code": "2",
             "label": "Expression"
           },
           "3": {
+            "code": "3",
             "label": "Manifestation"
           }
         }
@@ -10946,9 +13408,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC musical composition code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -10979,9 +13443,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -11017,12 +13483,15 @@
         "label": "Existence in LC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in LC"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in LC"
           }
         }
@@ -11031,27 +13500,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by LC"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided"
           },
-          "0": {
-            "label": "No series involved"
+          " ": {
+            "code": " ",
+            "label": "No information provided",
+            "deprecated": true
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           }
         }
       },
@@ -11085,11 +13560,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Supplementary class number (MU) [OBSOLETE, 1981]"
+          "label": "Supplementary class number (MU) [OBSOLETE, 1981]",
+          "deprecated": true
         }
       }
     },
@@ -11128,18 +13602,21 @@
         "label": "Code source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Library of Congress Classification"
           },
           "1": {
+            "code": "1",
             "label": "U.S. Dept. of Defense Classification"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]"
+            "code": "0",
+            "label": "U.S. Dept. of Defense Classification [OBSOLETE, 2002]",
+            "deprecated": true
           }
         }
       },
@@ -11179,11 +13656,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Subject (MP) [OBSOLETE]"
+          "label": "Subject (MP) [OBSOLETE]",
+          "deprecated": true
         }
       }
     },
@@ -11196,12 +13672,15 @@
         "label": "Existence in LAC collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Information not provided"
           },
           "0": {
+            "code": "0",
             "label": "Work held by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Work not held by LAC"
           }
         }
@@ -11210,33 +13689,43 @@
         "label": "Type, completeness, source of class/call number",
         "codes": {
           "0": {
+            "code": "0",
             "label": "LC-based call number assigned by LAC"
           },
           "1": {
+            "code": "1",
             "label": "Complete LC class number assigned by LAC"
           },
           "2": {
+            "code": "2",
             "label": "Incomplete LC class number assigned by LAC"
           },
           "3": {
+            "code": "3",
             "label": "LC-based call number assigned by the contributing library"
           },
           "4": {
+            "code": "4",
             "label": "Complete LC class number assigned by the contributing library"
           },
           "5": {
+            "code": "5",
             "label": "Incomplete LC class number assigned by the contributing library"
           },
           "6": {
+            "code": "6",
             "label": "Other call number assigned by LAC"
           },
           "7": {
+            "code": "7",
             "label": "Other class number assigned by LAC"
           },
           "8": {
+            "code": "8",
             "label": "Other call number assigned by the contributing library"
           },
           "9": {
+            "code": "9",
             "label": "Other class number assigned by the contributing library"
           }
         }
@@ -11284,12 +13773,15 @@
         "label": "Existence in NLM collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NLM"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NLM"
           }
         }
@@ -11298,27 +13790,33 @@
         "label": "Source of call number",
         "codes": {
           "0": {
-            "label": "Assigned by NLM"
+            "code": "0",
+            "label": "No series involved",
+            "deprecated": true
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than NLM"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "No series involved"
           },
           "1": {
-            "label": "Main series"
+            "code": "1",
+            "label": "Main series",
+            "deprecated": true
           },
           "2": {
-            "label": "Subseries"
+            "code": "2",
+            "label": "Subseries",
+            "deprecated": true
           },
           "3": {
-            "label": "Sub-subseries"
+            "code": "3",
+            "label": "Sub-subseries",
+            "deprecated": true
           },
           " ": {
-            "label": "No information provided [OBSOLETE]"
+            "code": " ",
+            "label": "No information provided [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -11403,12 +13901,15 @@
         "label": "Existence in NAL collection",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Item is in NAL"
           },
           "1": {
+            "code": "1",
             "label": "Item is not in NAL"
           }
         }
@@ -11474,15 +13975,17 @@
         "label": "Code source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "NAL subject category code list"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "undefined"
+            "code": " ",
+            "label": "undefined",
+            "deprecated": true
           }
         }
       },
@@ -11542,12 +14045,15 @@
         "label": "Type of edition",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Full"
           },
           "1": {
+            "code": "1",
             "label": "Abridged"
           }
         }
@@ -11599,21 +14105,26 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]"
+            "code": " ",
+            "label": "No edition information recorded (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           },
           "2": {
-            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]"
+            "code": "2",
+            "label": "Abridged NST version (BK, MU, VM, SE) [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -11621,18 +14132,17 @@
         "label": "Source of classification number",
         "codes": {
           " ": {
-            "label": "No information provided"
+            "code": " ",
+            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]",
+            "deprecated": true
           },
           "0": {
+            "code": "0",
             "label": "Assigned by LC"
           },
           "4": {
+            "code": "4",
             "label": "Assigned by agency other than LC"
-          }
-        },
-        "historical-codes": {
-          " ": {
-            "label": "No information provided [OBSOLETE] [USMARC only, BK, CF, MU, VM, SE]"
           }
         }
       },
@@ -11642,8 +14152,8 @@
           "repeatable": true
         },
         "b": {
-          "label": "Item number",
-          "repeatable": false
+          "label": "DDC number-abridged NST version (SE) [OBSOLETE]",
+          "deprecated": true
         },
         "m": {
           "label": "Standard or optional designation",
@@ -11671,11 +14181,6 @@
           "label": "Field link and sequence number",
           "repeatable": true
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "DDC number-abridged NST version (SE) [OBSOLETE]"
-        }
       }
     },
     "083": {
@@ -11687,12 +14192,15 @@
         "label": "Type of edition",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Full edition"
           },
           "1": {
+            "code": "1",
             "label": "Abridged edition"
           },
           "7": {
+            "code": "7",
             "label": "Other edition specified in subfield $2"
           }
         }
@@ -11878,24 +14386,23 @@
         "label": "Number source",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Source specified in subfield $2"
           },
           "0": {
-            "label": "Superintendent of Documents Classification System"
+            "code": "0",
+            "label": "United States",
+            "deprecated": true
           },
           "1": {
-            "label": "Government of Canada Publications: Outline of Classification"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "United States"
-          },
-          "1": {
-            "label": "Canada"
+            "code": "1",
+            "label": "Canada",
+            "deprecated": true
           },
           "2-9": {
-            "label": "Reserved"
+            "code": "2-9",
+            "label": "Reserved",
+            "deprecated": true
           }
         }
       },
@@ -11970,12 +14477,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -12085,12 +14595,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -12192,12 +14705,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -12303,6 +14819,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -12403,9 +14920,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -12414,9 +14933,11 @@
         "label": "Type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Abbreviated key title"
           },
           "0": {
+            "code": "0",
             "label": "Other abbreviated title"
           }
         }
@@ -12460,24 +14981,28 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
-            "label": "No nonfiling characters"
+            "code": "0",
+            "label": "Key title is same as field 245 / No key title added entry; title proper same",
+            "deprecated": true
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
-          "0": {
-            "label": "Key title is same as field 245 / No key title added entry; title proper same"
           },
           "1": {
-            "label": "Key title is not the same as field 245 / Key title added entry; title proper different"
+            "code": "1",
+            "label": "Key title is not the same as field 245 / Key title added entry; title proper different",
+            "deprecated": true
           },
           "2": {
-            "label": "Key title added entry; title proper same"
+            "code": "2",
+            "label": "Key title added entry; title proper same",
+            "deprecated": true
           },
           "3": {
-            "label": "No key title added entry; title proper different"
+            "code": "3",
+            "label": "No key title added entry; title proper different",
+            "deprecated": true
           }
         }
       },
@@ -12510,18 +15035,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -12529,6 +15058,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -12624,9 +15154,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -12635,9 +15167,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -12680,14 +15214,14 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
+          "label": "Designation of section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]"
+          "label": "Name of part/section (BK, AM, MP, MU, VM, SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -12700,18 +15234,22 @@
         "label": "Uniform title printed or displayed",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Not printed or displayed"
           },
           "1": {
+            "code": "1",
             "label": "Printed or displayed"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]"
+            "code": "2",
+            "label": "Not printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Selections (extracts) [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           },
           "3": {
-            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]"
+            "code": "3",
+            "label": "Printed on card, title added entry (MU) [USMARC only] [OBSOLETE, 1993] / Other collective titles [CAN/MARC only] [OBSOLETE]",
+            "deprecated": true
           }
         }
       },
@@ -12719,6 +15257,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -12796,9 +15335,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -12807,9 +15348,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -12867,14 +15410,14 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of part/section/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -12887,15 +15430,19 @@
         "label": "Note/added entry controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Note, no added entry"
           },
           "1": {
+            "code": "1",
             "label": "Note, added entry"
           },
           "2": {
+            "code": "2",
             "label": "No note, no added entry"
           },
           "3": {
+            "code": "3",
             "label": "No note, added entry"
           }
         }
@@ -12904,33 +15451,43 @@
         "label": "Type of title",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Portion of title"
           },
           "1": {
+            "code": "1",
             "label": "Parallel title"
           },
           "2": {
+            "code": "2",
             "label": "Distinctive title"
           },
           "3": {
+            "code": "3",
             "label": "Other title"
           },
           "4": {
+            "code": "4",
             "label": "Cover title"
           },
           "5": {
+            "code": "5",
             "label": "Added title page title"
           },
           "6": {
+            "code": "6",
             "label": "Caption title"
           },
           "7": {
+            "code": "7",
             "label": "Running title"
           },
           "8": {
+            "code": "8",
             "label": "Spine title"
           }
         }
@@ -12985,17 +15542,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "c": {
-          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]"
+          "label": "Remainder of title page transcription [OBSOLETE, 1991] [CAN/MARC only]",
+          "deprecated": true
         },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         }
       }
     },
@@ -13008,9 +15566,11 @@
         "label": "Title added entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No added entry"
           },
           "1": {
+            "code": "1",
             "label": "Added entry"
           }
         }
@@ -13019,9 +15579,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -13071,17 +15633,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Designation of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "e": {
-          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]"
+          "label": "Name of section/part/series (SE) [OBSOLETE, 1979]",
+          "deprecated": true
         },
         "c": {
-          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]"
+          "label": "Remainder of Title Page transcription [OBSOLETE] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -13334,21 +15897,26 @@
         "label": "Sequence of publishing statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest available publisher"
           },
           "2": {
+            "code": "2",
             "label": "Intervening publisher"
           },
           "3": {
+            "code": "3",
             "label": "Current/latest publisher"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Publisher, distributor, etc. is present"
+            "code": "0",
+            "label": "Publisher, distributor, etc. is present",
+            "deprecated": true
           },
           "1": {
-            "label": "Publisher, distributor, etc. not present"
+            "code": "1",
+            "label": "Publisher, distributor, etc. not present",
+            "deprecated": true
           }
         }
       },
@@ -13390,17 +15958,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]"
+          "label": "Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1981] [CAN/MARC only] / Plate or publisher's number for music (Pre-AACR2) [OBSOLETE, 1999] [USMARC only]",
+          "deprecated": true
         },
         "k": {
-          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Identification/manufacturer number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         },
         "l": {
-          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Matrix and/or take number [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -13436,12 +16005,15 @@
         "label": "Sequence of statements",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not applicable/No information provided/Earliest"
           },
           "2": {
+            "code": "2",
             "label": "Intervening"
           },
           "3": {
+            "code": "3",
             "label": "Current/Latest"
           }
         }
@@ -13450,18 +16022,23 @@
         "label": "Function of entity",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Production"
           },
           "1": {
+            "code": "1",
             "label": "Publication"
           },
           "2": {
+            "code": "2",
             "label": "Distribution"
           },
           "3": {
+            "code": "3",
             "label": "Manufacture"
           },
           "4": {
+            "code": "4",
             "label": "Copyright notice date"
           }
         }
@@ -13507,12 +16084,15 @@
         "label": "Level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -13521,12 +16101,15 @@
         "label": "Type of address",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No type specified"
           },
           "0": {
+            "code": "0",
             "label": "Mailing"
           },
           "7": {
+            "code": "7",
             "label": "Type specified in subfield $i"
           }
         }
@@ -13668,17 +16251,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "d": {
-          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]"
+          "label": "Accompanying material [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "m": {
-          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Identification/manufacturer number [pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         },
         "n": {
-          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]"
+          "label": "Matrix and/or take number [Sound recordings, pre-AACR2 records only] [OBSOLETE, 1988] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -13714,9 +16298,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Hours"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -14166,12 +16752,15 @@
         "label": "Application",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Adaptive features to access primary content"
           },
           "1": {
+            "code": "1",
             "label": "Adaptive features to access secondary content"
           }
         }
@@ -14226,9 +16815,11 @@
         "label": "Geospatial reference dimension",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Horizontal coordinate system"
           },
           "1": {
+            "code": "1",
             "label": "Vertical coordinate system"
           }
         }
@@ -14237,30 +16828,39 @@
         "label": "Geospatial reference method",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Geographic"
           },
           "1": {
+            "code": "1",
             "label": "Map projection"
           },
           "2": {
+            "code": "2",
             "label": "Grid coordinate system"
           },
           "3": {
+            "code": "3",
             "label": "Local planar"
           },
           "4": {
+            "code": "4",
             "label": "Local"
           },
           "5": {
+            "code": "5",
             "label": "Geodetic model"
           },
           "6": {
+            "code": "6",
             "label": "Altitude"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in $2"
           },
           "8": {
+            "code": "8",
             "label": "Depth"
           }
         }
@@ -14860,24 +17460,31 @@
         "label": "Controlled element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Document"
           },
           "1": {
+            "code": "1",
             "label": "Title"
           },
           "2": {
+            "code": "2",
             "label": "Abstract"
           },
           "3": {
+            "code": "3",
             "label": "Contents note"
           },
           "4": {
+            "code": "4",
             "label": "Author"
           },
           "5": {
+            "code": "5",
             "label": "Record"
           },
           "8": {
+            "code": "8",
             "label": "None of the above"
           }
         }
@@ -14977,12 +17584,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -15070,9 +17680,11 @@
         "label": "Format of date",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Formatted style"
           },
           "1": {
+            "code": "1",
             "label": "Unformatted note"
           }
         }
@@ -15107,12 +17719,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -15121,12 +17736,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -15220,12 +17838,15 @@
         "label": "Start/End designator",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Starting information"
           },
           "1": {
+            "code": "1",
             "label": "Ending information"
           }
         }
@@ -15234,12 +17855,15 @@
         "label": "State of issuance",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "0": {
+            "code": "0",
             "label": "Closed"
           },
           "1": {
+            "code": "1",
             "label": "Open"
           }
         }
@@ -15462,9 +18086,11 @@
         "label": "Source of code",
         "codes": {
           " ": {
+            "code": " ",
             "label": "MARC language code"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in $2"
           }
         }
@@ -15618,18 +18244,23 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Medium of performance"
           },
           "1": {
+            "code": "1",
             "label": "Partial medium of performance"
           },
           "2": {
+            "code": "2",
             "label": "Medium of performance of musical content of representative expression"
           },
           "3": {
+            "code": "3",
             "label": "Partial medium of performance of musical content of representative expression"
           }
         }
@@ -15638,12 +18269,15 @@
         "label": "Access control",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not intended for access"
           },
           "1": {
+            "code": "1",
             "label": "Intended for access"
           }
         }
@@ -15783,15 +18417,19 @@
         "label": "Key type",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Relationship to original unknown"
           },
           "0": {
+            "code": "0",
             "label": "Original key"
           },
           "1": {
+            "code": "1",
             "label": "Transposed key"
           },
           "2": {
+            "code": "2",
             "label": "Key of representative expression"
           }
         }
@@ -16054,12 +18692,15 @@
         "label": "Type of time period",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "Creation of work"
           },
           "2": {
+            "code": "2",
             "label": "Creation of aggregate work"
           }
         }
@@ -16111,12 +18752,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -16125,9 +18769,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -16218,12 +18864,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -16232,9 +18881,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "1": {
+            "code": "1",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -16325,12 +18976,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -16339,9 +18993,11 @@
         "label": "Pronoun represents main entry",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Main entry not represented by pronoun"
           },
           "9": {
+            "code": "9",
             "label": "Main entry represented by pronoun"
           }
         }
@@ -16433,9 +19089,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -16478,11 +19136,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "h": {
-          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]"
+          "label": "General material designation [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         }
       }
     },
@@ -16495,9 +19152,11 @@
         "label": "Series tracing policy",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Series not traced"
           },
           "1": {
+            "code": "1",
             "label": "Series traced"
           }
         }
@@ -16579,17 +19238,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "l": {
-          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]"
+          "label": "Library of Congress call number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "x": {
-          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]"
+          "label": "International Standard Serial Number (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "z": {
-          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -16707,15 +19367,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Contents"
           },
           "1": {
+            "code": "1",
             "label": "Incomplete contents"
           },
           "2": {
+            "code": "2",
             "label": "Partial contents"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -16724,9 +19388,11 @@
         "label": "Level of content designation",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Enhanced"
           }
         }
@@ -16776,12 +19442,15 @@
         "label": "Restriction",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No restrictions"
           },
           "1": {
+            "code": "1",
             "label": "Restrictions apply"
           }
         }
@@ -16911,18 +19580,23 @@
         "label": "Coverage/location in source",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Coverage unknown"
           },
           "1": {
+            "code": "1",
             "label": "Coverage complete"
           },
           "2": {
+            "code": "2",
             "label": "Coverage is selective"
           },
           "3": {
+            "code": "3",
             "label": "Location in source not given"
           },
           "4": {
+            "code": "4",
             "label": "Location in source given"
           }
         }
@@ -16977,18 +19651,22 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No display constant generated"
           },
           "1": {
+            "code": "1",
             "label": "Cast"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Presenter (VM, MU) [OBSOLETE, 1993]"
+            "code": "2",
+            "label": "Presenter (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Narrator (VM, MU) [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Narrator (VM, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -17135,11 +19813,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -17152,9 +19829,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Type of file"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17242,24 +19921,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Summary"
           },
           "0": {
+            "code": "0",
             "label": "Subject"
           },
           "1": {
+            "code": "1",
             "label": "Review"
           },
           "2": {
+            "code": "2",
             "label": "Scope and content"
           },
           "3": {
+            "code": "3",
             "label": "Abstract"
           },
           "4": {
+            "code": "4",
             "label": "Content advice"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17303,11 +19989,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (BK, AM, CF, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -17320,24 +20005,31 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Audience"
           },
           "0": {
+            "code": "0",
             "label": "Reading grade level"
           },
           "1": {
+            "code": "1",
             "label": "Interest age level"
           },
           "2": {
+            "code": "2",
             "label": "Interest grade level"
           },
           "3": {
+            "code": "3",
             "label": "Special audience characteristics"
           },
           "4": {
+            "code": "4",
             "label": "Motivation/interest level"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17376,9 +20068,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Geographic coverage"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17409,9 +20103,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Cite as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17462,11 +20158,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -17479,9 +20174,11 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Reading program"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17572,11 +20269,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -17589,15 +20285,19 @@
         "label": "Display constant controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Accessibility technical details"
           },
           "1": {
+            "code": "1",
             "label": "Accessibility features"
           },
           "2": {
+            "code": "2",
             "label": "Accessibility deficiencies"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -17616,11 +20316,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (AM, CF, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -17908,18 +20607,22 @@
         "label": "Custodial role",
         "codes": {
           "1": {
+            "code": "1",
             "label": "Holder of originals"
           },
           "2": {
+            "code": "2",
             "label": "Holder of duplicates"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Repository (AM) [OBSOLETE, 1984]"
+            "code": "0",
+            "label": "Repository (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           },
           "3": {
-            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]"
+            "code": "3",
+            "label": "Holder of oral tapes (AM) [OBSOLETE, 1984]",
+            "deprecated": true
           }
         }
       },
@@ -18124,12 +20827,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -18200,12 +20906,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -18316,12 +21025,15 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Associated materials"
           },
           "1": {
+            "code": "1",
             "label": "Related materials"
           }
         }
@@ -18376,12 +21088,15 @@
         "label": "Type of data",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Biographical sketch"
           },
           "1": {
+            "code": "1",
             "label": "Administrative history"
           }
         }
@@ -18443,11 +21158,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18471,11 +21185,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18503,11 +21216,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information (SE) [OBSOLETE, 1990]"
+          "label": "Source of note information (SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18611,12 +21323,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Indexes"
           },
           "0": {
+            "code": "0",
             "label": "Finding aids"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18671,9 +21386,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Documentation"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18708,12 +21425,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -18744,11 +21464,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Time of collation (NR) [OBSOLETE, 1997]"
+          "label": "Time of collation (NR) [OBSOLETE, 1997]",
+          "deprecated": true
         }
       }
     },
@@ -18843,12 +21562,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "File size"
           },
           "0": {
+            "code": "0",
             "label": "Case file characteristics"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18899,9 +21621,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Methodology"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -18960,11 +21684,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "z": {
-          "label": "Source of note information [OBSOLETE, 1990]"
+          "label": "Source of note information [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -18977,9 +21700,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Publications"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -19018,12 +21743,15 @@
         "label": "Privacy",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Private"
           },
           "1": {
+            "code": "1",
             "label": "Not private"
           }
         }
@@ -19197,9 +21925,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Awards"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -19234,12 +21964,15 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Source of description"
           },
           "1": {
+            "code": "1",
             "label": "Latest issue consulted"
           }
         }
@@ -19274,18 +22007,21 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
-          }
-        },
-        "historical-codes": {
+          },
           "2": {
-            "label": "Multiple surname [OBSOLETE, 1996]"
+            "code": "2",
+            "label": "Multiple surname [OBSOLETE, 1996]",
+            "deprecated": true
           }
         }
       },
@@ -19293,27 +22029,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -19462,12 +22206,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -19476,27 +22223,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -19637,12 +22392,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -19651,27 +22409,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -19804,6 +22570,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -19812,27 +22579,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -19962,27 +22737,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20058,27 +22841,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20146,15 +22937,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -20163,27 +22958,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20194,8 +22997,8 @@
           "repeatable": false
         },
         "b": {
-          "label": "Topical term following geographic name entry element",
-          "repeatable": false
+          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]",
+          "deprecated": true
         },
         "c": {
           "label": "Location of event",
@@ -20265,11 +23068,6 @@
           "label": "Field link and sequence number",
           "repeatable": true
         }
-      },
-      "historical-subfields": {
-        "b": {
-          "label": "Topical term following geographic name as entry element [OBSOLETE, 1981]"
-        }
       }
     },
     "651": {
@@ -20282,27 +23080,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20371,11 +23177,10 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Geographic name following place entry element [OBSOLETE, 1981]"
+          "label": "Geographic name following place entry element [OBSOLETE, 1981]",
+          "deprecated": true
         }
       }
     },
@@ -20388,15 +23193,19 @@
         "label": "Level of index term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -20405,27 +23214,35 @@
         "label": "Type of term or name",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Topical term"
           },
           "1": {
+            "code": "1",
             "label": "Personal name"
           },
           "2": {
+            "code": "2",
             "label": "Corporate name"
           },
           "3": {
+            "code": "3",
             "label": "Meeting name"
           },
           "4": {
+            "code": "4",
             "label": "Chronological term"
           },
           "5": {
+            "code": "5",
             "label": "Geographic name"
           },
           "6": {
+            "code": "6",
             "label": "Genre/form term"
           }
         }
@@ -20472,15 +23289,19 @@
         "label": "Level of subject",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "No level specified"
           },
           "1": {
+            "code": "1",
             "label": "Primary"
           },
           "2": {
+            "code": "2",
             "label": "Secondary"
           }
         }
@@ -20558,9 +23379,11 @@
         "label": "Type of heading",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Basic"
           },
           "0": {
+            "code": "0",
             "label": "Faceted"
           }
         }
@@ -20569,27 +23392,35 @@
         "label": "Thesaurus",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Library of Congress Subject Headings"
           },
           "1": {
+            "code": "1",
             "label": "LC subject headings for children's literature"
           },
           "2": {
+            "code": "2",
             "label": "Medical Subject Headings"
           },
           "3": {
+            "code": "3",
             "label": "National Agricultural Library subject authority file"
           },
           "4": {
+            "code": "4",
             "label": "Source not specified"
           },
           "5": {
+            "code": "5",
             "label": "Canadian Subject Headings"
           },
           "6": {
+            "code": "6",
             "label": "Répertoire de vedettes-matière"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20670,6 +23501,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20738,6 +23570,7 @@
         "label": "Source of term",
         "codes": {
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20921,9 +23754,11 @@
         "label": "Source of name, title, or term",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -20984,12 +23819,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -20998,9 +23836,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -21145,12 +23985,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -21159,9 +24002,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -21298,12 +24143,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -21312,9 +24160,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -21443,12 +24293,15 @@
         "label": "Type of name",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Not specified"
           },
           "1": {
+            "code": "1",
             "label": "Personal"
           },
           "2": {
+            "code": "2",
             "label": "Other"
           }
         }
@@ -21505,6 +24358,7 @@
         "label": "Nonfiling characters",
         "codes": {
           "0-9": {
+            "code": "0-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -21513,9 +24367,11 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
           }
         }
@@ -21632,15 +24488,17 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
-          }
-        },
-        "historical-codes": {
+          },
           " ": {
-            "label": "Nonfiling characters not specified [OBSOLETE, 1980]"
+            "code": " ",
+            "label": "Nonfiling characters not specified [OBSOLETE, 1980]",
+            "deprecated": true
           }
         }
       },
@@ -21648,21 +24506,27 @@
         "label": "Type of added entry",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "2": {
+            "code": "2",
             "label": "Analytical entry"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]"
+            "code": "0",
+            "label": "Alternative entry (BK, AM, CF, MP, MU) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "1": {
-            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]"
+            "code": "1",
+            "label": "Secondary entry (BK, AM, CF, MP, MU) / Printed on card (VM) [OBSOLETE, 1993]",
+            "deprecated": true
           },
           "3": {
-            "label": "Not printed on card [OBSOLETE, 1993]"
+            "code": "3",
+            "label": "Not printed on card [OBSOLETE, 1993]",
+            "deprecated": true
           }
         }
       },
@@ -21987,9 +24851,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -21998,9 +24864,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Main series"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22226,9 +25094,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -22237,9 +25107,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has subseries"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22465,9 +25337,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -22476,9 +25350,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translation of"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22720,9 +25596,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -22731,9 +25609,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Translated as"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -22975,9 +25855,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -22986,9 +25868,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Has supplement"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -23230,9 +26114,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -23241,18 +26127,21 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Supplement to"
           },
           "0": {
+            "code": "0",
             "label": "Parent"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "1": {
-            "label": "Special issue [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "Special issue [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -23493,9 +26382,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -23504,9 +26395,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "In"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -23757,9 +26650,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -23768,15 +26663,17 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Constituent unit"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Includes [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Includes [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -24017,9 +26914,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24028,21 +26927,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Other edition available"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Entry not the same"
+            "code": "0",
+            "label": "Entry not the same",
+            "deprecated": true
           },
           "1": {
-            "label": "Entry is the same as title"
+            "code": "1",
+            "label": "Entry is the same as title",
+            "deprecated": true
           },
           "2": {
-            "label": "Entry is the same as main entry and title"
+            "code": "2",
+            "label": "Entry is the same as main entry and title",
+            "deprecated": true
           }
         }
       },
@@ -24291,9 +27196,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24302,9 +27209,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Available in another form"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -24546,9 +27455,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24557,21 +27468,27 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Issued with"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
-          }
-        },
-        "historical-codes": {
+          },
           "0": {
-            "label": "Issued with [OBSOLETE] [CAN/MARC only]"
+            "code": "0",
+            "label": "Issued with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "1": {
-            "label": "With [OBSOLETE] [CAN/MARC only]"
+            "code": "1",
+            "label": "With [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           },
           "2": {
-            "label": "Bound with [OBSOLETE] [CAN/MARC only]"
+            "code": "2",
+            "label": "Bound with [OBSOLETE] [CAN/MARC only]",
+            "deprecated": true
           }
         }
       },
@@ -24812,9 +27729,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -24823,27 +27742,35 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continues"
           },
           "1": {
+            "code": "1",
             "label": "Continues in part"
           },
           "2": {
+            "code": "2",
             "label": "Supersedes"
           },
           "3": {
+            "code": "3",
             "label": "Supersedes in part"
           },
           "4": {
+            "code": "4",
             "label": "Formed by the union of ... and ..."
           },
           "5": {
+            "code": "5",
             "label": "Absorbed"
           },
           "6": {
+            "code": "6",
             "label": "Absorbed in part"
           },
           "7": {
+            "code": "7",
             "label": "Separated from"
           }
         }
@@ -25086,9 +28013,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25097,30 +28026,39 @@
         "label": "Type of relationship",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Continued by"
           },
           "1": {
+            "code": "1",
             "label": "Continued in part by"
           },
           "2": {
+            "code": "2",
             "label": "Superseded by"
           },
           "3": {
+            "code": "3",
             "label": "Superseded in part by"
           },
           "4": {
+            "code": "4",
             "label": "Absorbed by"
           },
           "5": {
+            "code": "5",
             "label": "Absorbed in part by"
           },
           "6": {
+            "code": "6",
             "label": "Split into ... and ..."
           },
           "7": {
+            "code": "7",
             "label": "Merged with ... to form ..."
           },
           "8": {
+            "code": "8",
             "label": "Changed back to"
           }
         }
@@ -25362,9 +28300,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25373,9 +28313,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Data source"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25629,9 +28571,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25640,9 +28584,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Related item"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25884,9 +28830,11 @@
         "label": "Note controller",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Display note"
           },
           "1": {
+            "code": "1",
             "label": "Do not display note"
           }
         }
@@ -25895,9 +28843,11 @@
         "label": "Display constant controller",
         "codes": {
           " ": {
+            "code": " ",
             "label": "Parallel description in another language of cataloging"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -25976,12 +28926,15 @@
         "label": "Type of personal name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Forename"
           },
           "1": {
+            "code": "1",
             "label": "Surname"
           },
           "3": {
+            "code": "3",
             "label": "Family name"
           }
         }
@@ -26216,12 +29169,15 @@
         "label": "Type of corporate name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -26448,12 +29404,15 @@
         "label": "Type of meeting name entry element",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Inverted name"
           },
           "1": {
+            "code": "1",
             "label": "Jurisdiction name"
           },
           "2": {
+            "code": "2",
             "label": "Name in direct order"
           }
         }
@@ -26673,9 +29632,11 @@
         "label": "Nonfiling characters",
         "codes": {
           "0": {
+            "code": "0",
             "label": "No nonfiling characters"
           },
           "1-9": {
+            "code": "1-9",
             "label": "Number of nonfiling characters"
           }
         }
@@ -26948,17 +29909,18 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
+        },
         "b": {
-          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Holdings (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "d": {
-          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Inclusive dates (MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         },
         "e": {
-          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]"
+          "label": "Retention statement (CF, MU, VM, SE) [OBSOLETE, 1990]",
+          "deprecated": true
         }
       }
     },
@@ -26971,33 +29933,43 @@
         "label": "Shelving scheme",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Library of Congress classification"
           },
           "1": {
+            "code": "1",
             "label": "Dewey Decimal classification"
           },
           "2": {
+            "code": "2",
             "label": "National Library of Medicine classification"
           },
           "3": {
+            "code": "3",
             "label": "Superintendent of Documents classification"
           },
           "4": {
+            "code": "4",
             "label": "Shelving control number"
           },
           "5": {
+            "code": "5",
             "label": "Title"
           },
           "6": {
+            "code": "6",
             "label": "Shelved separately"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           },
           "8": {
+            "code": "8",
             "label": "Other scheme"
           }
         }
@@ -27006,15 +29978,19 @@
         "label": "Shelving order",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Not enumeration"
           },
           "1": {
+            "code": "1",
             "label": "Primary enumeration"
           },
           "2": {
+            "code": "2",
             "label": "Alternative enumeration"
           }
         }
@@ -27135,24 +30111,31 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Email"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "2": {
+            "code": "2",
             "label": "Remote login (Telnet)"
           },
           "3": {
+            "code": "3",
             "label": "Dial-up"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -27161,24 +30144,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -27205,24 +30195,24 @@
           "repeatable": true
         },
         "g": {
-          "label": "Persistent identifier",
-          "repeatable": true
+          "label": "Uniform Resource Name [OBSOLETE, 2000]",
+          "deprecated": true
         },
         "h": {
-          "label": "Non-functioning Uniform Resource Identifier",
-          "repeatable": true
+          "label": "Processor of request [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "l": {
-          "label": "Standardized information governing access",
-          "repeatable": true
+          "label": "Logon [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "m": {
           "label": "Contact for access assistance",
           "repeatable": true
         },
         "n": {
-          "label": "Terms governing access",
-          "repeatable": true
+          "label": "Name of location of host [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "o": {
           "label": "Operating system",
@@ -27237,16 +30227,16 @@
           "repeatable": true
         },
         "r": {
-          "label": "Standardized information governing use and reproduction",
-          "repeatable": true
+          "label": "Settings [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "s": {
           "label": "File size",
           "repeatable": true
         },
         "t": {
-          "label": "Terms governing use and reproduction",
-          "repeatable": true
+          "label": "Terminal emulation [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "u": {
           "label": "Uniform Resource Identifier",
@@ -27294,38 +30284,22 @@
         "8": {
           "label": "Field link and sequence number",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
-        "g": {
-          "label": "Uniform Resource Name [OBSOLETE, 2000]"
         },
         "b": {
-          "label": "Access number [OBSOLETE, 2020]"
-        },
-        "h": {
-          "label": "Processor of request [OBSOLETE, 2020]"
+          "label": "Access number [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "i": {
-          "label": "Instruction [OBSOLETE, 2020]"
+          "label": "Instruction [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "j": {
-          "label": "Bits per second [OBSOLETE, 2020]"
+          "label": "Bits per second [OBSOLETE, 2020]",
+          "deprecated": true
         },
         "k": {
-          "label": "Password [OBSOLETE, 2020]"
-        },
-        "l": {
-          "label": "Logon [OBSOLETE, 2020]"
-        },
-        "n": {
-          "label": "Name of location of host [OBSOLETE, 2020]"
-        },
-        "r": {
-          "label": "Settings [OBSOLETE, 2020]"
-        },
-        "t": {
-          "label": "Terminal emulation [OBSOLETE, 2020]"
+          "label": "Password [OBSOLETE, 2020]",
+          "deprecated": true
         }
       }
     },
@@ -27338,15 +30312,19 @@
         "label": "Access method",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "1": {
+            "code": "1",
             "label": "FTP"
           },
           "4": {
+            "code": "4",
             "label": "HTTP"
           },
           "7": {
+            "code": "7",
             "label": "Method specified in subfield $2"
           }
         }
@@ -27355,24 +30333,31 @@
         "label": "Relationship",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "0": {
+            "code": "0",
             "label": "Resource"
           },
           "1": {
+            "code": "1",
             "label": "Version of resource"
           },
           "2": {
+            "code": "2",
             "label": "Related resource"
           },
           "3": {
+            "code": "3",
             "label": "Component part(s) of resource"
           },
           "4": {
+            "code": "4",
             "label": "Version of component part(s) of resource"
           },
           "8": {
+            "code": "8",
             "label": "No display constant generated"
           }
         }
@@ -27487,15 +30472,19 @@
         "label": "Field encoding level",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided"
           },
           "3": {
+            "code": "3",
             "label": "Holdings level 3"
           },
           "4": {
+            "code": "4",
             "label": "Holdings level 4"
           },
           "5": {
+            "code": "5",
             "label": "Holdings level 4 with piece designation"
           }
         }
@@ -27504,15 +30493,19 @@
         "label": "Type of notation",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Non-standard"
           },
           "1": {
+            "code": "1",
             "label": "ANSI/NISO Z39.71 or ISO 10324"
           },
           "2": {
+            "code": "2",
             "label": "ANSI Z39.42"
           },
           "7": {
+            "code": "7",
             "label": "Source specified in subfield $2"
           }
         }
@@ -27820,15 +30813,19 @@
         "label": "Method of assignment",
         "codes": {
           " ": {
+            "code": " ",
             "label": "No information provided/not applicable"
           },
           "0": {
+            "code": "0",
             "label": "Fully machine-generated"
           },
           "1": {
+            "code": "1",
             "label": "Partially machine-generated"
           },
           "2": {
+            "code": "2",
             "label": "Not machine-generated"
           }
         }
@@ -27975,12 +30972,15 @@
         "label": "Type of field",
         "codes": {
           "0": {
+            "code": "0",
             "label": "Leader"
           },
           "1": {
+            "code": "1",
             "label": "Variable control fields (002-009)"
           },
           "2": {
+            "code": "2",
             "label": "Variable data fields (010-999)"
           }
         }
@@ -28000,12 +31000,12 @@
           "repeatable": true
         },
         "c": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true
+          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "d": {
-          "label": "Foreign MARC subfield",
-          "repeatable": true
+          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]",
+          "deprecated": true
         },
         "e": {
           "label": "Foreign MARC subfield",
@@ -28130,14 +31130,6 @@
         "9": {
           "label": "Foreign MARC subfield",
           "repeatable": true
-        }
-      },
-      "historical-subfields": {
-        "c": {
-          "label": "Content of the foreign MARC control fields 002-009 [OBSOLETE, 1997] [CAN/MARC only]"
-        },
-        "d": {
-          "label": "Content designators and data elements of the foreign MARC variable fields 010-999 [OBSOLETE, 1997] [CAN/MARC only]"
         }
       }
     },

--- a/src/main/java/de/gwdg/metadataqa/marc/cli/utils/MappingToJson.java
+++ b/src/main/java/de/gwdg/metadataqa/marc/cli/utils/MappingToJson.java
@@ -208,25 +208,26 @@ public class MappingToJson {
     if (generator != null)
       values.put("solr", generator.forSubfield(subfield));
 
+    LinkedHashMap<String, Object> codes = new LinkedHashMap<>();
     if (subfield.getCodes() != null) {
-      LinkedHashMap<String, Object> codes = new LinkedHashMap<>();
       for (EncodedValue code : subfield.getCodes()) {
         Map<String, Object> codeMap = new LinkedHashMap<>();
-        // codeMap.put("code", code.getCode());
+        codeMap.put("code", code.getCode());
         codeMap.put("label", code.getLabel());
         codes.put(code.getCode(), codeMap);
       }
-      values.put("codes", codes);
     }
     if (subfield.getHistoricalCodes() != null) {
-      LinkedHashMap<String, Object> codes = new LinkedHashMap<>();
       for (EncodedValue code : subfield.getHistoricalCodes()) {
         Map<String, Object> codeMap = new LinkedHashMap<>();
-        // codeMap.put("code", code.getCode());
+        codeMap.put("code", code.getCode());
         codeMap.put("label", code.getLabel());
+        codeMap.put("deprecated", true);
         codes.put(code.getCode(), codeMap);
       }
-      values.put("historical-codes", codes);
+    }
+    if (codes.size() > 0) {
+      values.put("codes", codes);
     }
     return values;
   }
@@ -262,6 +263,16 @@ public class MappingToJson {
     } else {
       logger.info(tag + " does not have subfields");
     }
+
+    if (tag.getHistoricalSubfields() != null) {
+      for (EncodedValue code : tag.getHistoricalSubfields()) {
+        Map<String, Object> subfieldDefinition = new LinkedHashMap<>();
+        subfieldDefinition.put("label", code.getLabel());
+        subfieldDefinition.put("deprecated", true);
+        subfields.put(code.getCode(), subfieldDefinition);
+      }
+    }
+
     tagMap.put("subfields", subfields);
 
     if (parameters.isWithLocallyDefinedFields()) {
@@ -279,16 +290,6 @@ public class MappingToJson {
         if (!versionSpecificSubfieldsMap.isEmpty())
           tagMap.put("versionSpecificSubfields", versionSpecificSubfieldsMap);
       }
-    }
-
-    if (tag.getHistoricalSubfields() != null) {
-      subfields = new LinkedHashMap<>();
-      for (EncodedValue code : tag.getHistoricalSubfields()) {
-        Map<String, Object> labelMap = new LinkedHashMap<>();
-        labelMap.put("label", code.getLabel());
-        subfields.put(code.getCode(), labelMap);
-      }
-      tagMap.put("historical-subfields", subfields);
     }
 
     if (fields.containsKey(tag.getTag())) {
@@ -444,24 +445,31 @@ public class MappingToJson {
     if (!indicator.exists()) {
       return null;
     }
-    Map<String, Object> value = new LinkedHashMap<>();
+    Map<String, Object> value = new LinkedHashMap<>();    
     value.put("label", indicator.getLabel());
+
     Map<String, Object> codes = new LinkedHashMap<>();
-    for (EncodedValue code : indicator.getCodes()) {
-      Map<String, Object> map = new LinkedHashMap<>();
-      map.put("label", code.getLabel());
-      codes.put(code.getCode(), map);
-    }
-    value.put("codes", codes);
-    if (indicator.getHistoricalCodes() != null) {
-      codes = new LinkedHashMap<>();
-      for (EncodedValue code : indicator.getHistoricalCodes()) {
+    if (indicator.getCodes() != null) {
+      for (EncodedValue code : indicator.getCodes()) {
         Map<String, Object> map = new LinkedHashMap<>();
+        map.put("code", code.getCode());
         map.put("label", code.getLabel());
         codes.put(code.getCode(), map);
       }
-      value.put("historical-codes", codes);
     }
+    if (indicator.getHistoricalCodes() != null) {
+      for (EncodedValue code : indicator.getHistoricalCodes()) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("code", code.getCode());
+        map.put("label", code.getLabel());
+        map.put("deprecated", true);
+        codes.put(code.getCode(), map);
+      }
+    }
+    if (codes.size() > 0) { 
+      value.put("codes", codes);
+    }
+
     return value;
   }
 


### PR DESCRIPTION
As discussed in #391 use a `deprecated` flag.